### PR TITLE
Add Last Beacon to Strategy & simulation

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -14,7 +14,7 @@ Playful ideas, games you can try, and development stories that inspire the next 
 
 ## Start here
 
-Explore **3 browser games and 1 interactive particle-art sandbox**: soft-body fruit merging, one-tap flight, magic-carpet combat, and Orbital Garden. Click a title to open its demo or source with setup instructions.
+Explore **4 browser games and 1 interactive particle-art sandbox**: soft-body fruit merging, one-tap flight, magic-carpet combat, island power-grid tower defense, and Orbital Garden. Click a title to open its demo or source with setup instructions.
 
 Last checked: **2026-09-05**. Creator statements, source links, and demo availability have been checked. Model attribution is author-reported; the games have not been play-tested for this list.
 
@@ -63,7 +63,11 @@ Logic puzzles, physics challenges, word games, and clever little mechanisms.
 
 Tower defense, strategic card games, management games, building, and simulation sandboxes.
 
-*Waiting for the first game.*
+- **[Last Beacon / 最后的灯塔](https://last-beacon.loupengju.cc)** — Connect a power grid across a miniature island, build and upgrade towers, and balance limited power to defend a lighthouse through ten waves and a final boss.
+  - Creator: [stackloomdev](https://github.com/stackloomdev)
+  - Platform: Modern desktop and mobile browsers, with Chinese and English support; free, no login or API key. Optional sound requires Web Audio.
+  - GPT-6 Astra: [Creator's development log and model contribution](https://github.com/stackloomdev/last-beacon/blob/main/docs/CREATION.md) — Used for gameplay design, code, procedural artwork, and tests through multiple iterations; not a one-shot test.
+  - Resources: [Source and setup instructions](https://github.com/stackloomdev/last-beacon) · [Requirements and iteration notes](https://github.com/stackloomdev/last-beacon/blob/main/docs/PROMPT.md) · Built with: JavaScript, Canvas 2D, and Web Audio.
 
 ### RPGs & adventures
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ## 从这里开始
 
-目前收录 **3 款浏览器游戏和 1 个交互式粒子艺术沙盒**：半流体水果合成、单键飞行、魔毯战斗，以及轨道花园。点击作品名称可打开试玩或源码运行说明。
+目前收录 **4 款浏览器游戏和 1 个交互式粒子艺术沙盒**：半流体水果合成、单键飞行、魔毯战斗、海岛电网塔防，以及轨道花园。点击作品名称可打开试玩或源码运行说明。
 
 最近核对：**2026-09-05**。已检查作者的 Astra 使用说明、源码链接和演示页面可达性；模型归因来自作者自述，尚未逐款试玩。
 
@@ -63,7 +63,11 @@
 
 塔防、卡牌策略、经营建造与模拟沙盒。
 
-*等待首个作品。*
+- **[最后的灯塔 / Last Beacon](https://last-beacon.loupengju.cc)** — 在微缩海岛上连接电网、布置并升级炮塔，以有限电力抵挡十波机械生物和最终 Boss，守住灯塔。
+  - 作者：[stackloomdev](https://github.com/stackloomdev)
+  - 平台：现代桌面与手机浏览器，中英双语；免费，无需登录或 API Key；可选音效需要 Web Audio。
+  - GPT-6 Astra：[作者的创作记录与模型参与说明](https://github.com/stackloomdev/last-beacon/blob/main/docs/CREATION.md) — 参与玩法设计、代码、程序化美术和测试；多轮迭代，非 one-shot 测试。
+  - 开发资料：[源码与运行说明](https://github.com/stackloomdev/last-beacon) · [需求与迭代记录](https://github.com/stackloomdev/last-beacon/blob/main/docs/PROMPT.md) · 技术：JavaScript、Canvas 2D、Web Audio。
 
 ### RPG 与冒险
 


### PR DESCRIPTION
## 本次修改 / What changed

新增《最后的灯塔 / Last Beacon》到「策略与模拟 / Strategy & simulation」。玩家在微缩海岛上连接电网、布置和升级炮塔，以有限电力守住十波敌人与最终 Boss。

- 试玩：https://last-beacon.loupengju.cc
- 作者与源码：[stackloomdev/last-beacon](https://github.com/stackloomdev/last-beacon)
- 模型参与依据：[创作记录](https://github.com/stackloomdev/last-beacon/blob/main/docs/CREATION.md)；GPT-6 Astra 参与玩法设计、代码、程序化美术与测试，经过多轮迭代。
- 现代桌面与手机浏览器可玩，中英双语，免费，无需登录或 API Key；可选音效需要 Web Audio。

同步更新两份 README，移除该分类的空状态，并将数量更新为 4 款浏览器游戏和 1 个艺术沙盒。

## 实机截图 / Gameplay screenshots

2026-09-07 补充：原投稿已合并，截图文件及 README 预览另由 [补充 PR #6](https://github.com/MartinDelophy/awesome-gpt-6-astra/pull/6) 提交。

截图来自 Last Beacon 1.0.0（源码提交 [`102ca4c`](https://github.com/stackloomdev/last-beacon/commit/102ca4cfca542f9cca7a6020b12e20db78ac0003)）的本地实际运行：第 5 波战斗，正常资源预算，中英文界面。每张 PNG 为 1604 × 1600，约 0.58 MB。

中文：

![最后的灯塔中文实机截图：第 5 波防守中的炮塔、电网与敌人](https://raw.githubusercontent.com/stackloomdev/awesome-gpt-6-astra/f63de67c0a679b109ef9f67d337f15b135318a4b/assets/screenshots/last-beacon/gameplay.png)

English:

![Last Beacon English gameplay screenshot: towers, a connected power grid, and enemies during wave five](https://raw.githubusercontent.com/stackloomdev/awesome-gpt-6-astra/f63de67c0a679b109ef9f67d337f15b135318a4b/assets/screenshots/last-beacon/gameplay-en.png)

## 检查 / Quick check

- [x] 公开源码、作者署名及创作记录已核对；作者确认正式试玩域名可在未登录 Vercel 的浏览器中直接进入游戏。
- [x] 已说明玩法、访问条件及 GPT-6 Astra 的参与依据，并明确为多轮迭代。
- [x] `website` 的现有测试 27 项通过；实际解析两份 README，均得到 5 个作品，Last Beacon 的分类、作者、试玩和源码链接正确。
- [x] `git diff --check` 通过。
