### PR TITLE
docs: add GPT conversation link for APEX CLUB

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Parkour, platform challenges, racing, and games built around movement and routes
   - Creator: [MartinDelophy](https://github.com/MartinDelophy) (submitting account).
   - Platform: Desktop browser with WebGL 2 and a keyboard; free, no login or API key. Runs from a local HTTP server or static host; Three.js is included locally. Team races are local: one human and seven AI racers.
   - Model participation: [Development record](works/apex-club/CREATION.md) — Iterative Codex work on gameplay, code, procedural visuals and tests; GPT-6 Astra attribution awaits creator confirmation.
-  - Resources: [Source and setup](works/apex-club/README.md) · [Request and iteration summary](works/apex-club/PROMPTS.md) · Built with: JavaScript, Three.js.
+  - Resources: [Source and setup](works/apex-club/README.md) · [Request and iteration summary](works/apex-club/PROMPTS.md) · [GPT conversation](https://chatgpt.com/s/cx_6a9e84c13c9c8191bcb7ad0801288adc) · Built with: JavaScript, Three.js.
   - Preview: ![APEX CLUB team race on Bay Circuit with nearby karts, lap progress, live team points and a minimap.](assets/screenshots/apex-club/gameplay.png)
 
 - **[PELICAN PEDAL / 鹈鹕踏浪](https://pelican-pedal.zecoba.workers.dev/)** — Guide a cycling pelican along a changing 3D coastline: switch between three lanes, jump and duck around obstacles, collect fish combos, and use shields, magnets and a six-second invincible dash.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -90,7 +90,7 @@
   - 作者：[MartinDelophy](https://github.com/MartinDelophy)（当前提交账号）。
   - 平台：支持 WebGL 2 的桌面浏览器，键盘操作；免费，无需登录或 API Key；本地 HTTP 服务或静态网站启动，Three.js 已随源码提供。组队为 1 位玩家与 7 位 AI 的本地竞赛。
   - 模型参与：[开发记录](works/apex-club/CREATION.md) — 通过 Codex 多轮迭代玩法、代码、程序化美术与测试；GPT-6 Astra 归因待创作者确认。
-  - 开发资料：[源码与运行说明](works/apex-club/README.md) · [需求与迭代记录](works/apex-club/PROMPTS.md) · 技术：JavaScript、Three.js。
+  - 开发资料：[源码与运行说明](works/apex-club/README.md) · [需求与迭代记录](works/apex-club/PROMPTS.md) · [GPT 对话分享](https://chatgpt.com/s/cx_6a9e84c13c9c8191bcb7ad0801288adc) · 技术：JavaScript、Three.js。
   - 预览：![APEX CLUB 海湾赛道实机画面：卡丁车组队竞速，显示圈数、队伍积分和实时小地图。](assets/screenshots/apex-club/gameplay.png)
 
 - **[PELICAN PEDAL / 鹈鹕踏浪](https://pelican-pedal.zecoba.workers.dev/)** — 让鹈鹕骑着自行车穿行于不断变化的 3D 海岸，在三条车道间换道、跳跃与低头躲避障碍，连续收集小鱼获得连击，使用护盾、磁铁和六秒无敌冲刺。

--- a/works/apex-club/CREATION.md
+++ b/works/apex-club/CREATION.md
@@ -4,6 +4,10 @@
 
 Submitted through the authenticated [MartinDelophy](https://github.com/MartinDelophy) account. Exact GPT-6 Astra attribution is awaiting creator confirmation; the original attribution is not strengthened by this handling update. The model's precise identity is not inferred from the destination repository name.
 
+## Shared conversation
+
+[View the GPT conversation](https://chatgpt.com/s/cx_6a9e84c13c9c8191bcb7ad0801288adc) — a public, immutable snapshot of the Codex development task, shared on September 7, 2026. It captures the conversation at sharing time; later work is not automatically included.
+
 ## Workflow
 
 The project was iterated in Codex from an existing browser racing prototype, using the creator's requests and screenshots as feedback. This was a multi-turn development process, not a one-shot benchmark.

--- a/works/apex-club/README.md
+++ b/works/apex-club/README.md
@@ -80,7 +80,7 @@ Three.js 0.179.1 is distributed under the MIT license. The required runtime modu
 
 ![Charged drift with a complete kart silhouette and world-space tyre marks.](../../assets/screenshots/apex-club/gameplay.png)
 
-[Development record](CREATION.md) · [Request history](PROMPTS.md)
+[Development record](CREATION.md) · [Request history](PROMPTS.md) · [GPT conversation](https://chatgpt.com/s/cx_6a9e84c13c9c8191bcb7ad0801288adc)
 
 
 


### PR DESCRIPTION
Adds the creator-requested [public GPT conversation snapshot](https://chatgpt.com/s/cx_6a9e84c13c9c8191bcb7ad0801288adc) to the English and Chinese collection entries, the game README, and the creation record. The creation record explains that the link is an immutable snapshot and does not automatically include later work.

Documentation-only change based on the latest main branch. Existing attribution wording is preserved.