### PR TITLE
Sync game previews and Sunjing across all README translations

### DIFF
--- a/README.ar.md
+++ b/README.ar.md
@@ -24,7 +24,7 @@
 
 ## ابدأ من هنا
 
-استكشف **6 ألعاب للمتصفح وبيئة تفاعلية واحدة لفن الجسيمات**: دمج الفواكه المرنة، والطيران بزر واحد، والقتال على بساط سحري، والدفاع عن جزيرة بشبكة كهربائية، وسباقات الكارت على حلبة الخليج، وركوب الدراجة مع بجع على الساحل، وOrbital Garden. انقر على اسم العمل لفتح التجربة أو الشفرة المصدرية مع تعليمات التشغيل.
+استكشف **7 ألعاب للمتصفح وبيئة تفاعلية واحدة لفن الجسيمات**: دمج الفواكه المرنة، والطيران بزر واحد، والقتال على بساط سحري، والدفاع عن جزيرة بشبكة كهربائية، وسباقات الكارت على حلبة الخليج، وركوب الدراجة مع بجع على الساحل، وOrbital Garden. انقر على اسم العمل لفتح التجربة أو الشفرة المصدرية مع تعليمات التشغيل.
 
 آخر تحقق: **2026-09-05**. جرى التحقق من تصريحات المبدعين وروابط الشفرة المصدرية وإمكانية الوصول إلى العروض التجريبية. نَسب استخدام النموذج يستند إلى تصريحات المؤلفين؛ ولم تُختبر الألعاب باللعب من أجل إعداد هذه القائمة.
 
@@ -54,12 +54,14 @@
   - المنصة: المتصفح، مع تصميم موجه للأجهزة المحمولة.
   - GPT-6 Astra: [اختبارات المبدع بالتوليد من طلب واحد والموجّهات الأصلية](https://github.com/Ayi1337/gpt6-astra-one-shot-games/blob/main/README.md).
   - موارد التطوير: [الشفرة المصدرية](https://github.com/Ayi1337/gpt6-astra-one-shot-games/tree/main/mosswing/src) · [ملف HTML مستقل](https://github.com/Ayi1337/gpt6-astra-one-shot-games/blob/main/mosswing/mosswing.html)
+  - معاينة: ![Mosswing — شاشة البداية](assets/screenshots/mosswing/gameplay.jpg)
 
 - **[Magic Carpet Wizard — A Thousand Skies](https://threapchills.github.io/MagicCarpetWizard/)** — حلّق على بساط سحري في عالم كروي، واعبر الحلقات، وألقِ التعويذات، وقاتل الأعداء والزعماء.
   - المبدع: [threapchills](https://github.com/threapchills)
   - المنصة: متصفح على حاسوب مع فأرة ولوحة مفاتيح؛ يتطلب WebGL 2.
   - GPT-6 Astra: يذكر المبدع في [قسم About بالمستودع](https://github.com/threapchills/MagicCarpetWizard) أن اللعبة صُنعت باستخدام GPT-6 Astra.
   - موارد التطوير: [الشفرة المصدرية وتعليمات التشغيل](https://github.com/threapchills/MagicCarpetWizard) · التقنيات: Three.js, Vite.
+  - معاينة: ![Magic Carpet Wizard — شاشة البداية](assets/screenshots/magic-carpet/gameplay.jpg)
 
 <a id="puzzles"></a>
 
@@ -72,6 +74,14 @@
   - المنصة: متصفح حديث؛ يوفر المبدع أيضًا نسخة HTML مستقلة قابلة للتنزيل.
   - GPT-6 Astra: [اختبارات المبدع بالتوليد من طلب واحد والموجّهات الأصلية](https://github.com/Ayi1337/gpt6-astra-one-shot-games/blob/main/README.md).
   - موارد التطوير: [الشفرة المصدرية](https://github.com/Ayi1337/gpt6-astra-one-shot-games/tree/main/melon-lab/src) · [ملف HTML مستقل](https://github.com/Ayi1337/gpt6-astra-one-shot-games/blob/main/melon-lab/%E7%93%9C%E4%BD%93%E5%AE%9E%E9%AA%8C%E5%AE%A4.html)
+  - معاينة: ![Melon Lab — شاشة اللعبة](assets/screenshots/melon-lab/gameplay.jpg)
+
+- **[榫境 / Sunjing Puzzles](https://sunjing-puzzles.hp20230404.chatgpt.site)** — ورشة ثلاثية الأبعاد لتفكيك لغز خشبي من ست قطع وحل لوحتين من هوارونغ داو، مع تلميحات والتراجع عن الحركة.
+  - [MartinDelophy](https://github.com/MartinDelophy)
+  - متصفح يدعم WebGL 2، واجهة صينية، فأرة ولوحة مفاتيح ولمس. مجاني دون تسجيل دخول؛ يُحفظ التقدم في المتصفح.
+  - تطوير تكراري باستخدام Codex؛ استخدام GPT-6 Astra بانتظار تأكيد المؤلف. [Codex / GPT-6 Astra](works/sunjing-puzzles/CREATION.md)
+  - [المصدر وتعليمات التشغيل](works/sunjing-puzzles/README.md) · React, Vinext/Vite, Three.js.
+  - معاينة: ![Sunjing Puzzles — شاشة اللعبة](assets/screenshots/sunjing-puzzles/gameplay.jpg)
 
 <a id="strategy-simulation"></a>
 
@@ -125,6 +135,7 @@
   - المنصة: متصفح حديث يدعم WebGL؛ انقر على الاسم للتجربة عبر الإنترنت. مجانية ولا تتطلب تسجيل الدخول أو مفتاح API؛ يعمل ملف HTML المستقل دون اتصال أيضًا. الصوت المحيطي اختياري ويتطلب Web Audio.
   - GPT-6 Astra: [سجل الإنشاء ومساهمة النموذج](works/orbital-garden/README.md#模型与创作记录) — استخدم المبدع GPT-6 Astra ultra للفكرة والشفرة والنصوص، مع مراجعة تعاونية؛ وليس اختبارًا بالتوليد من طلب واحد.
   - موارد التطوير: [الشفرة المصدرية وتعليمات التشغيل](works/orbital-garden/README.md) · [ملف HTML مستقل](works/orbital-garden/index.html) · [Prompt](works/orbital-garden/PROMPT.md) · التقنيات: WebGL مباشرة, Web Audio, Canvas 2D.
+  - معاينة: ![ORBITAL GARDEN — شاشة اللعبة](assets/screenshots/orbital-garden/gameplay.jpg)
 
 ## ما الذي يتضمنه كل إدراج
 

--- a/README.de.md
+++ b/README.de.md
@@ -22,7 +22,7 @@ Diese Seite übersetzt die [englische README](README.md). Aktuelle Änderungen l
 
 ## Hier anfangen
 
-Entdecke **6 Browserspiele und 1 interaktiven Sandkasten für Partikelkunst**: weiche Früchte verschmelzen, mit einer Taste fliegen, auf einem fliegenden Teppich kämpfen, eine Insel mit einem Stromnetz verteidigen, Kartrennen auf Bay Circuit, eine Küstenradtour mit einem Pelikan und Orbital Garden. Ein Klick auf einen Titel öffnet die Demo oder den Quellcode mit Startanleitung.
+Entdecke **7 Browserspiele und 1 interaktiven Sandkasten für Partikelkunst**: weiche Früchte verschmelzen, mit einer Taste fliegen, auf einem fliegenden Teppich kämpfen, eine Insel mit einem Stromnetz verteidigen, Kartrennen auf Bay Circuit, eine Küstenradtour mit einem Pelikan und Orbital Garden. Ein Klick auf einen Titel öffnet die Demo oder den Quellcode mit Startanleitung.
 
 Zuletzt geprüft: **2026-09-05**. Angaben der Entwickler, Quellcode-Links und die Erreichbarkeit der Demos wurden geprüft. Die Modellnutzung beruht auf Angaben der Autoren; für diese Liste wurden keine Spieltests durchgeführt.
 
@@ -52,12 +52,14 @@ Shooter, Kampf-, Überlebens- und Rhythmusspiele sowie alles, was zu einer weite
   - Plattform: Browser, für Mobilgeräte entwickelt.
   - GPT-6 Astra: [One-Shot-Tests und ursprüngliche Prompts des Entwicklers](https://github.com/Ayi1337/gpt6-astra-one-shot-games/blob/main/README.md).
   - Materialien: [Quellcode](https://github.com/Ayi1337/gpt6-astra-one-shot-games/tree/main/mosswing/src) · [Eigenständige HTML-Datei](https://github.com/Ayi1337/gpt6-astra-one-shot-games/blob/main/mosswing/mosswing.html)
+  - Vorschau: ![Mosswing — Startbildschirm](assets/screenshots/mosswing/gameplay.jpg)
 
 - **[Magic Carpet Wizard — A Thousand Skies](https://threapchills.github.io/MagicCarpetWizard/)** — Fliege auf einem Teppich durch eine kugelförmige Welt, durchquere Ringe, wirke Zauber und bekämpfe Gegner und Bosse.
   - Entwickler: [threapchills](https://github.com/threapchills)
   - Plattform: Desktop-Browser mit Maus und Tastatur; benötigt WebGL 2.
   - GPT-6 Astra: Der Entwickler gibt im [About-Bereich des Repositorys](https://github.com/threapchills/MagicCarpetWizard) an, das Spiel mit GPT-6 Astra erstellt zu haben.
   - Materialien: [Quellcode und Startanleitung](https://github.com/threapchills/MagicCarpetWizard) · Technik: Three.js, Vite.
+  - Vorschau: ![Magic Carpet Wizard — Startbildschirm](assets/screenshots/magic-carpet/gameplay.jpg)
 
 <a id="puzzles"></a>
 
@@ -70,6 +72,14 @@ Logikrätsel, Physikaufgaben, Wortspiele und raffinierte kleine Mechaniken.
   - Plattform: Moderner Browser; der Entwickler stellt außerdem eine eigenständige HTML-Version zum Herunterladen bereit.
   - GPT-6 Astra: [One-Shot-Tests und ursprüngliche Prompts des Entwicklers](https://github.com/Ayi1337/gpt6-astra-one-shot-games/blob/main/README.md).
   - Materialien: [Quellcode](https://github.com/Ayi1337/gpt6-astra-one-shot-games/tree/main/melon-lab/src) · [Eigenständige HTML-Datei](https://github.com/Ayi1337/gpt6-astra-one-shot-games/blob/main/melon-lab/%E7%93%9C%E4%BD%93%E5%AE%9E%E9%AA%8C%E5%AE%A4.html)
+  - Vorschau: ![Melon Lab — Spielansicht](assets/screenshots/melon-lab/gameplay.jpg)
+
+- **[榫境 / Sunjing Puzzles](https://sunjing-puzzles.hp20230404.chatgpt.site)** — Eine 3D-Werkstatt mit einem sechsteiligen Holzpuzzle und zwei Huarong-Dao-Schiebepuzzles, mit Hinweisen und Rückgängig-Funktion.
+  - [MartinDelophy](https://github.com/MartinDelophy)
+  - WebGL-2-Browser, chinesische Oberfläche, Maus/Tastatur und Touch. Kostenlos, ohne Anmeldung; Fortschritt im Browser gespeichert.
+  - Iterative Entwicklung mit Codex; GPT-6 Astra muss noch vom Ersteller bestätigt werden. [Codex / GPT-6 Astra](works/sunjing-puzzles/CREATION.md)
+  - [Quellcode und Startanleitung](works/sunjing-puzzles/README.md) · React, Vinext/Vite, Three.js.
+  - Vorschau: ![Sunjing Puzzles — Spielansicht](assets/screenshots/sunjing-puzzles/gameplay.jpg)
 
 <a id="strategy-simulation"></a>
 
@@ -123,6 +133,7 @@ Ungewöhnliche Spielmechaniken, Online-Wettkämpfe und kooperative Erlebnisse.
   - Plattform: Moderner Browser mit WebGL; ein Klick auf den Titel startet das Online-Erlebnis. Kostenlos, ohne Anmeldung oder API-Schlüssel; die eigenständige HTML-Datei funktioniert auch offline. Optionaler Umgebungston benötigt Web Audio.
   - GPT-6 Astra: [Entstehungsbericht und Modellbeitrag](works/orbital-garden/README.md#模型与创作记录) — Der Entwickler nutzte GPT-6 Astra ultra für Konzept, Code und Texte mit gemeinsamer Prüfung; kein One-Shot-Test.
   - Materialien: [Quellcode und Startanleitung](works/orbital-garden/README.md) · [Eigenständige HTML-Datei](works/orbital-garden/index.html) · [Prompt](works/orbital-garden/PROMPT.md) · Technik: natives WebGL, Web Audio, Canvas 2D.
+  - Vorschau: ![ORBITAL GARDEN — Spielansicht](assets/screenshots/orbital-garden/gameplay.jpg)
 
 ## Was ein Eintrag enthält
 

--- a/README.es.md
+++ b/README.es.md
@@ -22,7 +22,7 @@ Esta página es una traducción del [README en inglés](README.md). Consulta el 
 
 ## Empieza aquí
 
-Explora **6 juegos de navegador y 1 entorno interactivo de arte con partículas**: fusión de frutas deformables, vuelo con un solo botón, combates en alfombra mágica, defensa de una isla mediante una red eléctrica, carreras de karts en Bay Circuit, ciclismo costero con un pelícano y Orbital Garden. Haz clic en un título para abrir su demo o el código fuente con instrucciones de ejecución.
+Explora **7 juegos de navegador y 1 entorno interactivo de arte con partículas**: fusión de frutas deformables, vuelo con un solo botón, combates en alfombra mágica, defensa de una isla mediante una red eléctrica, carreras de karts en Bay Circuit, ciclismo costero con un pelícano y Orbital Garden. Haz clic en un título para abrir su demo o el código fuente con instrucciones de ejecución.
 
 Última comprobación: **2026-09-05**. Se han revisado las declaraciones de los creadores, los enlaces al código fuente y la disponibilidad de las demos. El uso del modelo se basa en lo declarado por los autores; no se han realizado pruebas de juego para esta lista.
 
@@ -52,12 +52,14 @@ Juegos de disparos, lucha, supervivencia, ritmo y cualquier propuesta que invite
   - Plataforma: Navegador, diseñado para móviles.
   - GPT-6 Astra: [Pruebas en una sola generación y prompts originales del creador](https://github.com/Ayi1337/gpt6-astra-one-shot-games/blob/main/README.md).
   - Recursos: [Código fuente](https://github.com/Ayi1337/gpt6-astra-one-shot-games/tree/main/mosswing/src) · [HTML independiente](https://github.com/Ayi1337/gpt6-astra-one-shot-games/blob/main/mosswing/mosswing.html)
+  - Vista previa: ![Mosswing — Pantalla de inicio](assets/screenshots/mosswing/gameplay.jpg)
 
 - **[Magic Carpet Wizard — A Thousand Skies](https://threapchills.github.io/MagicCarpetWizard/)** — Pilota una alfombra mágica por un mundo esférico, atraviesa aros, lanza hechizos y combate contra enemigos y jefes.
   - Creador: [threapchills](https://github.com/threapchills)
   - Plataforma: Navegador de escritorio con ratón y teclado; requiere WebGL 2.
   - GPT-6 Astra: El creador indica en la [sección About del repositorio](https://github.com/threapchills/MagicCarpetWizard) que el juego se hizo con GPT-6 Astra.
   - Recursos: [Código fuente e instrucciones de ejecución](https://github.com/threapchills/MagicCarpetWizard) · Tecnologías: Three.js, Vite.
+  - Vista previa: ![Magic Carpet Wizard — Pantalla de inicio](assets/screenshots/magic-carpet/gameplay.jpg)
 
 <a id="puzzles"></a>
 
@@ -70,6 +72,14 @@ Acertijos de lógica, desafíos de física, juegos de palabras y pequeños mecan
   - Plataforma: Navegador moderno; el creador también ofrece una versión HTML independiente para descargar.
   - GPT-6 Astra: [Pruebas en una sola generación y prompts originales del creador](https://github.com/Ayi1337/gpt6-astra-one-shot-games/blob/main/README.md).
   - Recursos: [Código fuente](https://github.com/Ayi1337/gpt6-astra-one-shot-games/tree/main/melon-lab/src) · [HTML independiente](https://github.com/Ayi1337/gpt6-astra-one-shot-games/blob/main/melon-lab/%E7%93%9C%E4%BD%93%E5%AE%9E%E9%AA%8C%E5%AE%A4.html)
+  - Vista previa: ![Melon Lab — Pantalla del juego](assets/screenshots/melon-lab/gameplay.jpg)
+
+- **[榫境 / Sunjing Puzzles](https://sunjing-puzzles.hp20230404.chatgpt.site)** — Un taller 3D para desmontar un rompecabezas de madera de seis piezas y resolver dos tableros de Huarong Dao, con pistas y opción de deshacer.
+  - [MartinDelophy](https://github.com/MartinDelophy)
+  - Navegador con WebGL 2, interfaz en chino, ratón/teclado y controles táctiles. Gratis, sin iniciar sesión; progreso guardado en el navegador.
+  - Desarrollo iterativo con Codex; el uso de GPT-6 Astra está pendiente de confirmación del creador. [Codex / GPT-6 Astra](works/sunjing-puzzles/CREATION.md)
+  - [Código e instrucciones](works/sunjing-puzzles/README.md) · React, Vinext/Vite, Three.js.
+  - Vista previa: ![Sunjing Puzzles — Pantalla del juego](assets/screenshots/sunjing-puzzles/gameplay.jpg)
 
 <a id="strategy-simulation"></a>
 
@@ -123,6 +133,7 @@ Mecánicas inusuales, competición en línea y experiencias cooperativas.
   - Plataforma: Navegador moderno con WebGL; haz clic en el título para probarlo en línea. Gratis, sin iniciar sesión ni usar una clave API; el HTML independiente también funciona sin conexión. El sonido ambiental opcional requiere Web Audio.
   - GPT-6 Astra: [Registro de creación y contribución del modelo](works/orbital-garden/README.md#模型与创作记录) — El creador utilizó GPT-6 Astra ultra para el concepto, el código y los textos, con revisión colaborativa; no fue una prueba en una sola generación.
   - Recursos: [Código fuente e instrucciones de ejecución](works/orbital-garden/README.md) · [HTML independiente](works/orbital-garden/index.html) · [Prompt](works/orbital-garden/PROMPT.md) · Tecnologías: WebGL nativo, Web Audio, Canvas 2D.
+  - Vista previa: ![ORBITAL GARDEN — Pantalla del juego](assets/screenshots/orbital-garden/gameplay.jpg)
 
 ## Qué incluye cada entrada
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -22,7 +22,7 @@ Cette page traduit le [README anglais](README.md). Consultez l’original pour v
 
 ## Pour commencer
 
-Découvrez **6 jeux pour navigateur et 1 bac à sable interactif d’art à particules** : fusion de fruits déformables, vol à une touche, combats sur tapis volant, défense d’île par un réseau électrique, course de karts sur Bay Circuit, balade côtière à vélo avec un pélican et Orbital Garden. Cliquez sur un titre pour ouvrir la démo ou le code source avec ses instructions de lancement.
+Découvrez **7 jeux pour navigateur et 1 bac à sable interactif d’art à particules** : fusion de fruits déformables, vol à une touche, combats sur tapis volant, défense d’île par un réseau électrique, course de karts sur Bay Circuit, balade côtière à vélo avec un pélican et Orbital Garden. Cliquez sur un titre pour ouvrir la démo ou le code source avec ses instructions de lancement.
 
 Dernière vérification : **2026-09-05**. Les déclarations des créateurs, les liens vers le code source et l’accessibilité des démos ont été vérifiés. L’utilisation du modèle est déclarée par les auteurs ; les jeux n’ont pas été testés en jeu pour cette liste.
 
@@ -52,12 +52,14 @@ Jeux de tir, de combat, de survie, de rythme et tous ceux qui donnent envie de r
   - Plateforme: Navigateur, conçu pour mobile.
   - GPT-6 Astra: [Tests en une seule génération et prompts d’origine du créateur](https://github.com/Ayi1337/gpt6-astra-one-shot-games/blob/main/README.md).
   - Ressources: [Code source](https://github.com/Ayi1337/gpt6-astra-one-shot-games/tree/main/mosswing/src) · [HTML autonome](https://github.com/Ayi1337/gpt6-astra-one-shot-games/blob/main/mosswing/mosswing.html)
+  - Aperçu: ![Mosswing — Écran de démarrage](assets/screenshots/mosswing/gameplay.jpg)
 
 - **[Magic Carpet Wizard — A Thousand Skies](https://threapchills.github.io/MagicCarpetWizard/)** — Pilotez un tapis volant autour d’un monde sphérique, traversez des anneaux, lancez des sorts et affrontez des ennemis et des boss.
   - Créateur: [threapchills](https://github.com/threapchills)
   - Plateforme: Navigateur sur ordinateur, avec clavier et souris ; nécessite WebGL 2.
   - GPT-6 Astra: Le créateur indique dans la [section About du dépôt](https://github.com/threapchills/MagicCarpetWizard) que le jeu a été réalisé avec GPT-6 Astra.
   - Ressources: [Code source et instructions de lancement](https://github.com/threapchills/MagicCarpetWizard) · Technologies: Three.js, Vite.
+  - Aperçu: ![Magic Carpet Wizard — Écran de démarrage](assets/screenshots/magic-carpet/gameplay.jpg)
 
 <a id="puzzles"></a>
 
@@ -70,6 +72,14 @@ Jeux de tir, de combat, de survie, de rythme et tous ceux qui donnent envie de r
   - Plateforme: Navigateur moderne ; le créateur propose aussi une version HTML autonome à télécharger.
   - GPT-6 Astra: [Tests en une seule génération et prompts d’origine du créateur](https://github.com/Ayi1337/gpt6-astra-one-shot-games/blob/main/README.md).
   - Ressources: [Code source](https://github.com/Ayi1337/gpt6-astra-one-shot-games/tree/main/melon-lab/src) · [HTML autonome](https://github.com/Ayi1337/gpt6-astra-one-shot-games/blob/main/melon-lab/%E7%93%9C%E4%BD%93%E5%AE%9E%E9%AA%8C%E5%AE%A4.html)
+  - Aperçu: ![Melon Lab — Écran de jeu](assets/screenshots/melon-lab/gameplay.jpg)
+
+- **[榫境 / Sunjing Puzzles](https://sunjing-puzzles.hp20230404.chatgpt.site)** — Un atelier 3D pour démonter un casse-tête en bois à six pièces et résoudre deux grilles de Huarong Dao, avec indices et annulation.
+  - [MartinDelophy](https://github.com/MartinDelophy)
+  - Navigateur WebGL 2, interface chinoise, souris/clavier et tactile. Gratuit, sans connexion ; progression conservée dans le navigateur.
+  - Développement itératif avec Codex ; utilisation de GPT-6 Astra en attente de confirmation par le créateur. [Codex / GPT-6 Astra](works/sunjing-puzzles/CREATION.md)
+  - [Code et lancement](works/sunjing-puzzles/README.md) · React, Vinext/Vite, Three.js.
+  - Aperçu: ![Sunjing Puzzles — Écran de jeu](assets/screenshots/sunjing-puzzles/gameplay.jpg)
 
 <a id="strategy-simulation"></a>
 
@@ -123,6 +133,7 @@ Mécaniques originales, compétition en ligne et expériences coopératives.
   - Plateforme: Navigateur moderne avec WebGL ; cliquez sur le titre pour essayer en ligne. Gratuit, sans connexion ni clé API ; le fichier HTML autonome fonctionne aussi hors ligne. L’ambiance sonore facultative nécessite Web Audio.
   - GPT-6 Astra: [Historique de création et contribution du modèle](works/orbital-garden/README.md#模型与创作记录) — Le créateur a utilisé GPT-6 Astra ultra pour le concept, le code et les textes, avec une relecture collaborative ; il ne s’agit pas d’un test en une seule génération.
   - Ressources: [Code source et instructions de lancement](works/orbital-garden/README.md) · [HTML autonome](works/orbital-garden/index.html) · [Prompt](works/orbital-garden/PROMPT.md) · Technologies: WebGL natif, Web Audio, Canvas 2D.
+  - Aperçu: ![ORBITAL GARDEN — Écran de jeu](assets/screenshots/orbital-garden/gameplay.jpg)
 
 ## Ce que contient une fiche
 

--- a/README.hi.md
+++ b/README.hi.md
@@ -22,7 +22,7 @@
 
 ## यहाँ से शुरू करें
 
-यहाँ **6 ब्राउज़र गेम और कणों से कला बनाने वाला 1 इंटरैक्टिव सैंडबॉक्स** शामिल हैं: मुलायम फलों को मिलाना, एक बटन से उड़ान, जादुई कालीन पर लड़ाई, बिजली के नेटवर्क से द्वीप की रक्षा, Bay Circuit पर कार्ट रेसिंग, पेलिकन के साथ तट पर साइकिल चलाना और Orbital Garden। किसी शीर्षक पर क्लिक करके उसका डेमो या चलाने के निर्देशों सहित स्रोत कोड खोलें।
+यहाँ **7 ब्राउज़र गेम और कणों से कला बनाने वाला 1 इंटरैक्टिव सैंडबॉक्स** शामिल हैं: मुलायम फलों को मिलाना, एक बटन से उड़ान, जादुई कालीन पर लड़ाई, बिजली के नेटवर्क से द्वीप की रक्षा, Bay Circuit पर कार्ट रेसिंग, पेलिकन के साथ तट पर साइकिल चलाना और Orbital Garden। किसी शीर्षक पर क्लिक करके उसका डेमो या चलाने के निर्देशों सहित स्रोत कोड खोलें।
 
 अंतिम जाँच: **2026-09-05**। रचनाकारों के कथन, स्रोत कोड के लिंक और डेमो की उपलब्धता जाँची गई है। मॉडल के उपयोग की जानकारी लेखकों के कथनों पर आधारित है; इस सूची के लिए गेमों का खेलकर परीक्षण नहीं किया गया है।
 
@@ -52,12 +52,14 @@
   - प्लैटफ़ॉर्म: ब्राउज़र; मोबाइल के लिए डिज़ाइन किया गया है।
   - GPT-6 Astra: [रचनाकार के एक ही अनुरोध से निर्माण के परीक्षण और मूल प्रॉम्प्ट](https://github.com/Ayi1337/gpt6-astra-one-shot-games/blob/main/README.md).
   - विकास संसाधन: [स्रोत कोड](https://github.com/Ayi1337/gpt6-astra-one-shot-games/tree/main/mosswing/src) · [स्वतंत्र HTML फ़ाइल](https://github.com/Ayi1337/gpt6-astra-one-shot-games/blob/main/mosswing/mosswing.html)
+  - पूर्वावलोकन: ![Mosswing — आरंभिक स्क्रीन](assets/screenshots/mosswing/gameplay.jpg)
 
 - **[Magic Carpet Wizard — A Thousand Skies](https://threapchills.github.io/MagicCarpetWizard/)** — जादुई कालीन पर गोलाकार दुनिया में उड़ें, छल्लों से गुज़रें, जादू करें और दुश्मनों व बॉस से लड़ें।
   - रचनाकार: [threapchills](https://github.com/threapchills)
   - प्लैटफ़ॉर्म: माउस और कीबोर्ड वाला डेस्कटॉप ब्राउज़र; WebGL 2 आवश्यक है।
   - GPT-6 Astra: रचनाकार ने [रिपॉज़िटरी के About खंड](https://github.com/threapchills/MagicCarpetWizard) में बताया है कि गेम GPT-6 Astra से बनाया गया है।
   - विकास संसाधन: [स्रोत कोड और चलाने के निर्देश](https://github.com/threapchills/MagicCarpetWizard) · तकनीक: Three.js, Vite.
+  - पूर्वावलोकन: ![Magic Carpet Wizard — आरंभिक स्क्रीन](assets/screenshots/magic-carpet/gameplay.jpg)
 
 <a id="puzzles"></a>
 
@@ -70,6 +72,14 @@
   - प्लैटफ़ॉर्म: आधुनिक ब्राउज़र; रचनाकार डाउनलोड करने योग्य स्वतंत्र HTML संस्करण भी उपलब्ध कराते हैं।
   - GPT-6 Astra: [रचनाकार के एक ही अनुरोध से निर्माण के परीक्षण और मूल प्रॉम्प्ट](https://github.com/Ayi1337/gpt6-astra-one-shot-games/blob/main/README.md).
   - विकास संसाधन: [स्रोत कोड](https://github.com/Ayi1337/gpt6-astra-one-shot-games/tree/main/melon-lab/src) · [स्वतंत्र HTML फ़ाइल](https://github.com/Ayi1337/gpt6-astra-one-shot-games/blob/main/melon-lab/%E7%93%9C%E4%BD%93%E5%AE%9E%E9%AA%8C%E5%AE%A4.html)
+  - पूर्वावलोकन: ![Melon Lab — गेम स्क्रीन](assets/screenshots/melon-lab/gameplay.jpg)
+
+- **[榫境 / Sunjing Puzzles](https://sunjing-puzzles.hp20230404.chatgpt.site)** — छह लकड़ी के टुकड़ों वाली पहेली खोलने और हुआरोंग दाओ के दो बोर्ड हल करने की 3D कार्यशाला। संकेत और चाल वापस लेने की सुविधा उपलब्ध है।
+  - [MartinDelophy](https://github.com/MartinDelophy)
+  - WebGL 2 ब्राउज़र, चीनी इंटरफ़ेस, माउस/कीबोर्ड और स्पर्श नियंत्रण। निःशुल्क, लॉगिन नहीं; प्रगति ब्राउज़र में सहेजी जाती है।
+  - Codex के साथ कई चरणों में विकास; GPT-6 Astra का उपयोग निर्माता की पुष्टि की प्रतीक्षा में है। [Codex / GPT-6 Astra](works/sunjing-puzzles/CREATION.md)
+  - [स्रोत और चलाने के निर्देश](works/sunjing-puzzles/README.md) · React, Vinext/Vite, Three.js.
+  - पूर्वावलोकन: ![Sunjing Puzzles — गेम स्क्रीन](assets/screenshots/sunjing-puzzles/gameplay.jpg)
 
 <a id="strategy-simulation"></a>
 
@@ -123,6 +133,7 @@
   - प्लैटफ़ॉर्म: WebGL समर्थित आधुनिक ब्राउज़र; ऑनलाइन आज़माने के लिए शीर्षक पर क्लिक करें। मुफ़्त, लॉगिन या API कुंजी की ज़रूरत नहीं; स्वतंत्र HTML फ़ाइल ऑफ़लाइन भी चलती है। वैकल्पिक परिवेशी ध्वनि के लिए Web Audio आवश्यक है।
   - GPT-6 Astra: [निर्माण का रिकॉर्ड और मॉडल का योगदान](works/orbital-garden/README.md#模型与创作记录) — रचनाकार ने अवधारणा, कोड और पाठ के लिए GPT-6 Astra ultra का उपयोग किया और सहयोगी समीक्षा की; यह एक ही अनुरोध से निर्माण का परीक्षण नहीं है।
   - विकास संसाधन: [स्रोत कोड और चलाने के निर्देश](works/orbital-garden/README.md) · [स्वतंत्र HTML फ़ाइल](works/orbital-garden/index.html) · [Prompt](works/orbital-garden/PROMPT.md) · तकनीक: WebGL (बिना फ़्रेमवर्क), Web Audio, Canvas 2D.
+  - पूर्वावलोकन: ![ORBITAL GARDEN — गेम स्क्रीन](assets/screenshots/orbital-garden/gameplay.jpg)
 
 ## हर प्रविष्टि में क्या शामिल है
 

--- a/README.id.md
+++ b/README.id.md
@@ -22,7 +22,7 @@ Halaman ini merupakan terjemahan [README bahasa Inggris](README.md). Periksa ver
 
 ## Mulai di sini
 
-Jelajahi **6 gim peramban dan 1 sandbox seni partikel interaktif**: penggabungan buah yang lentur, penerbangan satu tombol, pertempuran karpet ajaib, pertahanan pulau dengan jaringan listrik, balapan kart di Bay Circuit, bersepeda di pesisir bersama pelikan, serta Orbital Garden. Klik judul untuk membuka demo atau kode sumber beserta petunjuk menjalankannya.
+Jelajahi **7 gim peramban dan 1 sandbox seni partikel interaktif**: penggabungan buah yang lentur, penerbangan satu tombol, pertempuran karpet ajaib, pertahanan pulau dengan jaringan listrik, balapan kart di Bay Circuit, bersepeda di pesisir bersama pelikan, serta Orbital Garden. Klik judul untuk membuka demo atau kode sumber beserta petunjuk menjalankannya.
 
 Terakhir diperiksa: **2026-09-05**. Pernyataan kreator, tautan kode sumber, dan ketersediaan demo telah diperiksa. Penggunaan model didasarkan pada keterangan penulis; gim belum diuji melalui permainan untuk daftar ini.
 
@@ -52,12 +52,14 @@ Gim tembak-menembak, pertarungan, bertahan hidup, ritme, dan apa pun yang membua
   - Platform: Peramban, dirancang untuk perangkat seluler.
   - GPT-6 Astra: [Pengujian sekali generasi dan prompt asli kreator](https://github.com/Ayi1337/gpt6-astra-one-shot-games/blob/main/README.md).
   - Materi pengembangan: [Kode sumber](https://github.com/Ayi1337/gpt6-astra-one-shot-games/tree/main/mosswing/src) · [HTML mandiri](https://github.com/Ayi1337/gpt6-astra-one-shot-games/blob/main/mosswing/mosswing.html)
+  - Pratinjau: ![Mosswing — Layar awal](assets/screenshots/mosswing/gameplay.jpg)
 
 - **[Magic Carpet Wizard — A Thousand Skies](https://threapchills.github.io/MagicCarpetWizard/)** — Terbangkan karpet ajaib melintasi dunia berbentuk bola, lewati cincin, keluarkan mantra, dan lawan musuh serta bos.
   - Kreator: [threapchills](https://github.com/threapchills)
   - Platform: Peramban desktop dengan tetikus dan papan ketik; memerlukan WebGL 2.
   - GPT-6 Astra: Kreator menyatakan bahwa gim ini dibuat dengan GPT-6 Astra di [bagian About repositori](https://github.com/threapchills/MagicCarpetWizard).
   - Materi pengembangan: [Kode sumber dan petunjuk menjalankan](https://github.com/threapchills/MagicCarpetWizard) · Teknologi: Three.js, Vite.
+  - Pratinjau: ![Magic Carpet Wizard — Layar awal](assets/screenshots/magic-carpet/gameplay.jpg)
 
 <a id="puzzles"></a>
 
@@ -70,6 +72,14 @@ Teka-teki logika, tantangan fisika, permainan kata, dan mekanisme kecil yang kre
   - Platform: Peramban modern; kreator juga menyediakan versi HTML mandiri yang dapat diunduh.
   - GPT-6 Astra: [Pengujian sekali generasi dan prompt asli kreator](https://github.com/Ayi1337/gpt6-astra-one-shot-games/blob/main/README.md).
   - Materi pengembangan: [Kode sumber](https://github.com/Ayi1337/gpt6-astra-one-shot-games/tree/main/melon-lab/src) · [HTML mandiri](https://github.com/Ayi1337/gpt6-astra-one-shot-games/blob/main/melon-lab/%E7%93%9C%E4%BD%93%E5%AE%9E%E9%AA%8C%E5%AE%A4.html)
+  - Pratinjau: ![Melon Lab — Tampilan permainan](assets/screenshots/melon-lab/gameplay.jpg)
+
+- **[榫境 / Sunjing Puzzles](https://sunjing-puzzles.hp20230404.chatgpt.site)** — Bengkel 3D untuk membongkar teka-teki kayu enam bagian dan menyelesaikan dua papan Huarong Dao, dengan petunjuk dan pembatalan langkah.
+  - [MartinDelophy](https://github.com/MartinDelophy)
+  - Browser WebGL 2, antarmuka Mandarin, mouse/keyboard dan sentuh. Gratis, tanpa login; progres disimpan di browser.
+  - Pengembangan berulang dengan Codex; penggunaan GPT-6 Astra menunggu konfirmasi pembuat. [Codex / GPT-6 Astra](works/sunjing-puzzles/CREATION.md)
+  - [Kode dan petunjuk menjalankan](works/sunjing-puzzles/README.md) · React, Vinext/Vite, Three.js.
+  - Pratinjau: ![Sunjing Puzzles — Tampilan permainan](assets/screenshots/sunjing-puzzles/gameplay.jpg)
 
 <a id="strategy-simulation"></a>
 
@@ -123,6 +133,7 @@ Mekanisme tidak biasa, kompetisi daring, dan pengalaman bermain kooperatif.
   - Platform: Peramban modern dengan WebGL; klik judul untuk mencobanya secara daring. Gratis, tanpa login atau kunci API; HTML mandiri juga dapat dijalankan luring. Suara latar opsional memerlukan Web Audio.
   - GPT-6 Astra: [Catatan pembuatan dan kontribusi model](works/orbital-garden/README.md#模型与创作记录) — Kreator menggunakan GPT-6 Astra ultra untuk konsep, kode, dan teks, dengan peninjauan bersama; bukan pengujian sekali generasi.
   - Materi pengembangan: [Kode sumber dan petunjuk menjalankan](works/orbital-garden/README.md) · [HTML mandiri](works/orbital-garden/index.html) · [Prompt](works/orbital-garden/PROMPT.md) · Teknologi: WebGL murni, Web Audio, Canvas 2D.
+  - Pratinjau: ![ORBITAL GARDEN — Tampilan permainan](assets/screenshots/orbital-garden/gameplay.jpg)
 
 ## Isi setiap entri
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -22,7 +22,7 @@
 
 ## はじめに
 
-現在、**ブラウザーゲーム 6 作品と、インタラクティブなパーティクルアートのサンドボックス 1 作品**を掲載しています。柔らかい果物の合成、ワンボタン飛行、魔法の絨毯での戦闘、島の電力網を使うタワーディフェンス、海湾サーキットのカートレース、ペリカンとの海岸サイクリング、そして Orbital Garden。作品名をクリックすると、デモまたは実行手順付きのソースコードが開きます。
+現在、**ブラウザーゲーム 7 作品と、インタラクティブなパーティクルアートのサンドボックス 1 作品**を掲載しています。柔らかい果物の合成、ワンボタン飛行、魔法の絨毯での戦闘、島の電力網を使うタワーディフェンス、海湾サーキットのカートレース、ペリカンとの海岸サイクリング、そして Orbital Garden。作品名をクリックすると、デモまたは実行手順付きのソースコードが開きます。
 
 最終確認日：**2026-09-05**。作者によるモデル利用の説明、ソースコードへのリンク、デモへのアクセスを確認しています。モデルの利用状況は作者の申告に基づくもので、この一覧のための各作品のプレイテストは行っていません。
 
@@ -52,12 +52,14 @@
   - 対応環境: ブラウザー。モバイル向けに設計されています。
   - GPT-6 Astra: [作者の One Shot テストと元のプロンプト](https://github.com/Ayi1337/gpt6-astra-one-shot-games/blob/main/README.md).
   - 開発資料: [ソースコード](https://github.com/Ayi1337/gpt6-astra-one-shot-games/tree/main/mosswing/src) · [単一 HTML ファイル](https://github.com/Ayi1337/gpt6-astra-one-shot-games/blob/main/mosswing/mosswing.html)
+  - プレビュー: ![Mosswing — スタート画面](assets/screenshots/mosswing/gameplay.jpg)
 
 - **[Magic Carpet Wizard — A Thousand Skies](https://threapchills.github.io/MagicCarpetWizard/)** — 魔法の絨毯で球形の世界を飛び、リングをくぐり、魔法を放って敵やボスと戦います。
   - 作者: [threapchills](https://github.com/threapchills)
   - 対応環境: マウスとキーボードを使うデスクトップブラウザー。WebGL 2 が必要です。
   - GPT-6 Astra: 作者は[リポジトリの About 欄](https://github.com/threapchills/MagicCarpetWizard)で、GPT-6 Astra を使って制作したと説明しています。
   - 開発資料: [ソースコードと実行手順](https://github.com/threapchills/MagicCarpetWizard) · 使用技術: Three.js, Vite.
+  - プレビュー: ![Magic Carpet Wizard — スタート画面](assets/screenshots/magic-carpet/gameplay.jpg)
 
 <a id="puzzles"></a>
 
@@ -70,6 +72,14 @@
   - 対応環境: モダンブラウザー。作者はダウンロードして使える単一 HTML 版も公開しています。
   - GPT-6 Astra: [作者の One Shot テストと元のプロンプト](https://github.com/Ayi1337/gpt6-astra-one-shot-games/blob/main/README.md).
   - 開発資料: [ソースコード](https://github.com/Ayi1337/gpt6-astra-one-shot-games/tree/main/melon-lab/src) · [単一 HTML ファイル](https://github.com/Ayi1337/gpt6-astra-one-shot-games/blob/main/melon-lab/%E7%93%9C%E4%BD%93%E5%AE%9E%E9%AA%8C%E5%AE%A4.html)
+  - プレビュー: ![Melon Lab — ゲーム画面](assets/screenshots/melon-lab/gameplay.jpg)
+
+- **[榫境 / Sunjing Puzzles](https://sunjing-puzzles.hp20230404.chatgpt.site)** — 六つの木製パーツを取り外す組木パズルと、二種類の華容道を楽しめる 3D 工房。ヒントと取り消しに対応。
+  - [MartinDelophy](https://github.com/MartinDelophy)
+  - WebGL 2 対応ブラウザー、中国語 UI、マウス・キーボード・タッチ。無料、ログイン不要。進行状況はブラウザーに保存。
+  - Codex で反復制作。GPT-6 Astra の利用は作者の確認待ち。 [Codex / GPT-6 Astra](works/sunjing-puzzles/CREATION.md)
+  - [ソースと実行手順](works/sunjing-puzzles/README.md) · React, Vinext/Vite, Three.js.
+  - プレビュー: ![Sunjing Puzzles — ゲーム画面](assets/screenshots/sunjing-puzzles/gameplay.jpg)
 
 <a id="strategy-simulation"></a>
 
@@ -123,6 +133,7 @@
   - 対応環境: WebGL 対応のモダンブラウザー。作品名からオンラインで体験できます。無料で、ログインや API キーは不要です。単一 HTML 版はオフラインでも動作します。任意の環境音には Web Audio が必要です。
   - GPT-6 Astra: [制作記録とモデルの担当範囲](works/orbital-garden/README.md#模型与创作记录) — 作者は構想、コード、文章に GPT-6 Astra ultra を使用し、共同レビューを行っています。One Shot テストではありません。
   - 開発資料: [ソースコードと実行手順](works/orbital-garden/README.md) · [単一 HTML ファイル](works/orbital-garden/index.html) · [Prompt](works/orbital-garden/PROMPT.md) · 使用技術: 素の WebGL, Web Audio, Canvas 2D.
+  - プレビュー: ![ORBITAL GARDEN — ゲーム画面](assets/screenshots/orbital-garden/gameplay.jpg)
 
 ## 各作品に記載する情報
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -22,7 +22,7 @@
 
 ## 여기서 시작하기
 
-현재 **브라우저 게임 6개와 인터랙티브 파티클 아트 샌드박스 1개**를 소개합니다. 부드러운 과일 합치기, 원버튼 비행, 마법 양탄자 전투, 섬의 전력망을 이용한 타워 디펜스, 베이 서킷 카트 레이싱, 펠리컨과 함께하는 해안 자전거 달리기, 그리고 Orbital Garden을 만나 보세요. 작품명을 누르면 데모 또는 실행 안내가 포함된 소스 코드가 열립니다.
+현재 **브라우저 게임 7개와 인터랙티브 파티클 아트 샌드박스 1개**를 소개합니다. 부드러운 과일 합치기, 원버튼 비행, 마법 양탄자 전투, 섬의 전력망을 이용한 타워 디펜스, 베이 서킷 카트 레이싱, 펠리컨과 함께하는 해안 자전거 달리기, 그리고 Orbital Garden을 만나 보세요. 작품명을 누르면 데모 또는 실행 안내가 포함된 소스 코드가 열립니다.
 
 마지막 확인: **2026-09-05**. 제작자의 모델 사용 설명, 소스 코드 링크, 데모 접속 가능 여부를 확인했습니다. 모델 사용 여부는 제작자의 공개 설명에 근거하며, 이 목록을 위해 각 게임의 플레이 테스트를 수행한 것은 아닙니다.
 
@@ -52,12 +52,14 @@
   - 플랫폼: 브라우저. 모바일 기기를 고려해 설계되었습니다.
   - GPT-6 Astra: [제작자의 원샷 테스트와 최초 프롬프트](https://github.com/Ayi1337/gpt6-astra-one-shot-games/blob/main/README.md).
   - 개발 자료: [소스 코드](https://github.com/Ayi1337/gpt6-astra-one-shot-games/tree/main/mosswing/src) · [단일 HTML 파일](https://github.com/Ayi1337/gpt6-astra-one-shot-games/blob/main/mosswing/mosswing.html)
+  - 미리보기: ![Mosswing — 시작 화면](assets/screenshots/mosswing/gameplay.jpg)
 
 - **[Magic Carpet Wizard — A Thousand Skies](https://threapchills.github.io/MagicCarpetWizard/)** — 마법 양탄자를 타고 구형 세계를 탐험하며 고리를 통과하고 주문을 사용해 적과 보스를 상대합니다.
   - 제작자: [threapchills](https://github.com/threapchills)
   - 플랫폼: 마우스와 키보드를 사용하는 데스크톱 브라우저. WebGL 2가 필요합니다.
   - GPT-6 Astra: 제작자는 [저장소의 About 설명](https://github.com/threapchills/MagicCarpetWizard)에서 GPT-6 Astra로 제작했다고 밝힙니다.
   - 개발 자료: [소스 코드 및 실행 안내](https://github.com/threapchills/MagicCarpetWizard) · 사용 기술: Three.js, Vite.
+  - 미리보기: ![Magic Carpet Wizard — 시작 화면](assets/screenshots/magic-carpet/gameplay.jpg)
 
 <a id="puzzles"></a>
 
@@ -70,6 +72,14 @@
   - 플랫폼: 최신 브라우저. 제작자는 내려받아 실행할 수 있는 단일 HTML 버전도 제공합니다.
   - GPT-6 Astra: [제작자의 원샷 테스트와 최초 프롬프트](https://github.com/Ayi1337/gpt6-astra-one-shot-games/blob/main/README.md).
   - 개발 자료: [소스 코드](https://github.com/Ayi1337/gpt6-astra-one-shot-games/tree/main/melon-lab/src) · [단일 HTML 파일](https://github.com/Ayi1337/gpt6-astra-one-shot-games/blob/main/melon-lab/%E7%93%9C%E4%BD%93%E5%AE%9E%E9%AA%8C%E5%AE%A4.html)
+  - 미리보기: ![Melon Lab — 게임 화면](assets/screenshots/melon-lab/gameplay.jpg)
+
+- **[榫境 / Sunjing Puzzles](https://sunjing-puzzles.hp20230404.chatgpt.site)** — 6개 나무 부품을 분리하는 퍼즐과 두 가지 화용도를 즐기는 3D 공방. 힌트와 실행 취소를 지원합니다.
+  - [MartinDelophy](https://github.com/MartinDelophy)
+  - WebGL 2 브라우저, 중국어 UI, 마우스·키보드·터치. 무료이며 로그인 없이 이용하고 진행 상황은 브라우저에 저장됩니다.
+  - Codex로 반복 개발했습니다. GPT-6 Astra 사용은 제작자 확인을 기다리고 있습니다. [Codex / GPT-6 Astra](works/sunjing-puzzles/CREATION.md)
+  - [소스와 실행 방법](works/sunjing-puzzles/README.md) · React, Vinext/Vite, Three.js.
+  - 미리보기: ![Sunjing Puzzles — 게임 화면](assets/screenshots/sunjing-puzzles/gameplay.jpg)
 
 <a id="strategy-simulation"></a>
 
@@ -123,6 +133,7 @@
   - 플랫폼: WebGL을 지원하는 최신 브라우저. 작품명을 누르면 온라인으로 체험할 수 있습니다. 무료이며 로그인이나 API 키가 필요 없고, 단일 HTML 파일은 오프라인에서도 실행됩니다. 선택 기능인 환경음에는 Web Audio가 필요합니다.
   - GPT-6 Astra: [제작 기록과 모델 기여 설명](works/orbital-garden/README.md#模型与创作记录) — 제작자는 구상, 코드, 문구 작성에 GPT-6 Astra ultra를 사용하고 공동 검토를 거쳤습니다. 원샷 테스트가 아닙니다.
   - 개발 자료: [소스 코드 및 실행 안내](works/orbital-garden/README.md) · [단일 HTML 파일](works/orbital-garden/index.html) · [Prompt](works/orbital-garden/PROMPT.md) · 사용 기술: 순수 WebGL, Web Audio, Canvas 2D.
+  - 미리보기: ![ORBITAL GARDEN — 게임 화면](assets/screenshots/orbital-garden/gameplay.jpg)
 
 ## 각 항목에 담는 정보
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -22,7 +22,7 @@ Esta página é uma tradução do [README em inglês](README.md). Consulte o ori
 
 ## Comece por aqui
 
-Explore **6 jogos de navegador e 1 ambiente interativo de arte com partículas**: fusão de frutas deformáveis, voo com um toque, combates em tapete mágico, defesa de uma ilha com uma rede elétrica, corridas de kart no Bay Circuit, ciclismo pela costa com um pelicano e Orbital Garden. Clique em um título para abrir a demonstração ou o código-fonte com instruções de execução.
+Explore **7 jogos de navegador e 1 ambiente interativo de arte com partículas**: fusão de frutas deformáveis, voo com um toque, combates em tapete mágico, defesa de uma ilha com uma rede elétrica, corridas de kart no Bay Circuit, ciclismo pela costa com um pelicano e Orbital Garden. Clique em um título para abrir a demonstração ou o código-fonte com instruções de execução.
 
 Última verificação: **2026-09-05**. Foram conferidos os relatos dos criadores, os links do código-fonte e a disponibilidade das demonstrações. O uso do modelo é informado pelos próprios autores; não foram realizados testes de jogabilidade para esta lista.
 
@@ -52,12 +52,14 @@ Jogos de tiro, luta, sobrevivência, ritmo e qualquer experiência que dê vonta
   - Plataforma: Navegador, projetado para dispositivos móveis.
   - GPT-6 Astra: [Testes em uma única geração e prompts originais do criador](https://github.com/Ayi1337/gpt6-astra-one-shot-games/blob/main/README.md).
   - Recursos: [Código-fonte](https://github.com/Ayi1337/gpt6-astra-one-shot-games/tree/main/mosswing/src) · [HTML independente](https://github.com/Ayi1337/gpt6-astra-one-shot-games/blob/main/mosswing/mosswing.html)
+  - Prévia: ![Mosswing — Tela inicial](assets/screenshots/mosswing/gameplay.jpg)
 
 - **[Magic Carpet Wizard — A Thousand Skies](https://threapchills.github.io/MagicCarpetWizard/)** — Voe em um tapete mágico por um mundo esférico, atravesse anéis, lance feitiços e enfrente inimigos e chefes.
   - Criador: [threapchills](https://github.com/threapchills)
   - Plataforma: Navegador de computador com mouse e teclado; exige WebGL 2.
   - GPT-6 Astra: O criador informa na [seção About do repositório](https://github.com/threapchills/MagicCarpetWizard) que o jogo foi feito com GPT-6 Astra.
   - Recursos: [Código-fonte e instruções de execução](https://github.com/threapchills/MagicCarpetWizard) · Tecnologias: Three.js, Vite.
+  - Prévia: ![Magic Carpet Wizard — Tela inicial](assets/screenshots/magic-carpet/gameplay.jpg)
 
 <a id="puzzles"></a>
 
@@ -70,6 +72,14 @@ Desafios de lógica e física, jogos de palavras e pequenos mecanismos engenhoso
   - Plataforma: Navegador moderno; o criador também disponibiliza uma versão HTML independente para download.
   - GPT-6 Astra: [Testes em uma única geração e prompts originais do criador](https://github.com/Ayi1337/gpt6-astra-one-shot-games/blob/main/README.md).
   - Recursos: [Código-fonte](https://github.com/Ayi1337/gpt6-astra-one-shot-games/tree/main/melon-lab/src) · [HTML independente](https://github.com/Ayi1337/gpt6-astra-one-shot-games/blob/main/melon-lab/%E7%93%9C%E4%BD%93%E5%AE%9E%E9%AA%8C%E5%AE%A4.html)
+  - Prévia: ![Melon Lab — Tela do jogo](assets/screenshots/melon-lab/gameplay.jpg)
+
+- **[榫境 / Sunjing Puzzles](https://sunjing-puzzles.hp20230404.chatgpt.site)** — Uma oficina 3D para desmontar um quebra-cabeça de madeira de seis peças e resolver dois tabuleiros de Huarong Dao, com dicas e opção de desfazer.
+  - [MartinDelophy](https://github.com/MartinDelophy)
+  - Navegador com WebGL 2, interface em chinês, mouse/teclado e toque. Grátis, sem login; progresso salvo no navegador.
+  - Desenvolvimento iterativo com Codex; uso de GPT-6 Astra aguardando confirmação do criador. [Codex / GPT-6 Astra](works/sunjing-puzzles/CREATION.md)
+  - [Código e instruções](works/sunjing-puzzles/README.md) · React, Vinext/Vite, Three.js.
+  - Prévia: ![Sunjing Puzzles — Tela do jogo](assets/screenshots/sunjing-puzzles/gameplay.jpg)
 
 <a id="strategy-simulation"></a>
 
@@ -123,6 +133,7 @@ Mecânicas diferentes, competição online e experiências cooperativas.
   - Plataforma: Navegador moderno com WebGL; clique no título para experimentar online. Grátis, sem login ou chave de API; o HTML independente também funciona offline. O som ambiente opcional exige Web Audio.
   - GPT-6 Astra: [Registro de criação e contribuição do modelo](works/orbital-garden/README.md#模型与创作记录) — O criador usou GPT-6 Astra ultra para o conceito, o código e os textos, com revisão colaborativa; não foi um teste de geração única.
   - Recursos: [Código-fonte e instruções de execução](works/orbital-garden/README.md) · [HTML independente](works/orbital-garden/index.html) · [Prompt](works/orbital-garden/PROMPT.md) · Tecnologias: WebGL nativo, Web Audio, Canvas 2D.
+  - Prévia: ![ORBITAL GARDEN — Tela do jogo](assets/screenshots/orbital-garden/gameplay.jpg)
 
 ## O que cada entrada inclui
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -22,7 +22,7 @@
 
 ## С чего начать
 
-Здесь собраны **6 браузерных игр и 1 интерактивная художественная песочница с частицами**: объединение мягких фруктов, полёт одной кнопкой, сражения на ковре-самолёте, защита острова с помощью электросети, гонки на картах по Bay Circuit, велопрогулка с пеликаном вдоль берега и Orbital Garden. Нажмите на название, чтобы открыть демоверсию или исходный код с инструкцией по запуску.
+Здесь собраны **7 браузерных игр и 1 интерактивная художественная песочница с частицами**: объединение мягких фруктов, полёт одной кнопкой, сражения на ковре-самолёте, защита острова с помощью электросети, гонки на картах по Bay Circuit, велопрогулка с пеликаном вдоль берега и Orbital Garden. Нажмите на название, чтобы открыть демоверсию или исходный код с инструкцией по запуску.
 
 Последняя проверка: **2026-09-05**. Проверены заявления авторов, ссылки на исходный код и доступность демонстраций. Сведения об использовании модели приводятся со слов авторов; игровое тестирование для этой подборки не проводилось.
 
@@ -52,12 +52,14 @@
   - Платформа: Браузер; игра разработана с учётом мобильных устройств.
   - GPT-6 Astra: [Тесты создания за один запрос и исходные промпты автора](https://github.com/Ayi1337/gpt6-astra-one-shot-games/blob/main/README.md).
   - Материалы: [Исходный код](https://github.com/Ayi1337/gpt6-astra-one-shot-games/tree/main/mosswing/src) · [Автономный HTML-файл](https://github.com/Ayi1337/gpt6-astra-one-shot-games/blob/main/mosswing/mosswing.html)
+  - Предпросмотр: ![Mosswing — Стартовый экран](assets/screenshots/mosswing/gameplay.jpg)
 
 - **[Magic Carpet Wizard — A Thousand Skies](https://threapchills.github.io/MagicCarpetWizard/)** — Летайте на ковре-самолёте по сферическому миру, проходите сквозь кольца, применяйте заклинания и сражайтесь с врагами и боссами.
   - Автор: [threapchills](https://github.com/threapchills)
   - Платформа: Настольный браузер с мышью и клавиатурой; требуется WebGL 2.
   - GPT-6 Astra: В [разделе About репозитория](https://github.com/threapchills/MagicCarpetWizard) автор указывает, что игра создана с помощью GPT-6 Astra.
   - Материалы: [Исходный код и инструкция по запуску](https://github.com/threapchills/MagicCarpetWizard) · Технологии: Three.js, Vite.
+  - Предпросмотр: ![Magic Carpet Wizard — Стартовый экран](assets/screenshots/magic-carpet/gameplay.jpg)
 
 <a id="puzzles"></a>
 
@@ -70,6 +72,14 @@
   - Платформа: Современный браузер; автор также предлагает автономную HTML-версию для скачивания.
   - GPT-6 Astra: [Тесты создания за один запрос и исходные промпты автора](https://github.com/Ayi1337/gpt6-astra-one-shot-games/blob/main/README.md).
   - Материалы: [Исходный код](https://github.com/Ayi1337/gpt6-astra-one-shot-games/tree/main/melon-lab/src) · [Автономный HTML-файл](https://github.com/Ayi1337/gpt6-astra-one-shot-games/blob/main/melon-lab/%E7%93%9C%E4%BD%93%E5%AE%9E%E9%AA%8C%E5%AE%A4.html)
+  - Предпросмотр: ![Melon Lab — Игровой экран](assets/screenshots/melon-lab/gameplay.jpg)
+
+- **[榫境 / Sunjing Puzzles](https://sunjing-puzzles.hp20230404.chatgpt.site)** — 3D-мастерская с деревянной головоломкой из шести деталей и двумя раскладками Хуаронг Дао, с подсказками и отменой хода.
+  - [MartinDelophy](https://github.com/MartinDelophy)
+  - Браузер с WebGL 2, китайский интерфейс, мышь/клавиатура и сенсорное управление. Бесплатно, без входа; прогресс хранится в браузере.
+  - Итеративная разработка с Codex; использование GPT-6 Astra ожидает подтверждения автора. [Codex / GPT-6 Astra](works/sunjing-puzzles/CREATION.md)
+  - [Код и запуск](works/sunjing-puzzles/README.md) · React, Vinext/Vite, Three.js.
+  - Предпросмотр: ![Sunjing Puzzles — Игровой экран](assets/screenshots/sunjing-puzzles/gameplay.jpg)
 
 <a id="strategy-simulation"></a>
 
@@ -123,6 +133,7 @@
   - Платформа: Современный браузер с WebGL; нажмите на название для запуска онлайн. Бесплатно, без входа в аккаунт и ключа API; автономный HTML-файл работает и без интернета. Для необязательного фонового звука требуется Web Audio.
   - GPT-6 Astra: [История создания и вклад модели](works/orbital-garden/README.md#模型与创作记录) — Автор использовал GPT-6 Astra ultra для концепции, кода и текстов с совместной проверкой; это не тест создания за один запрос.
   - Материалы: [Исходный код и инструкция по запуску](works/orbital-garden/README.md) · [Автономный HTML-файл](works/orbital-garden/index.html) · [Prompt](works/orbital-garden/PROMPT.md) · Технологии: чистый WebGL, Web Audio, Canvas 2D.
+  - Предпросмотр: ![ORBITAL GARDEN — Игровой экран](assets/screenshots/orbital-garden/gameplay.jpg)
 
 ## Что содержит запись
 


### PR DESCRIPTION
Bring the remaining ten translations into line with the English and Chinese catalogs: add Mosswing, Magic Carpet and Melon Lab previews, add the missing Orbital Garden preview, and add Sunjing with its public demo, source, platform requirements and pending model-attribution note. Update translated counts to seven games plus one interactive sandbox. Preview labels and image descriptions are localized.

This follows merged PR #21. No deployment or game code changes.

Validation: all 12 README catalogs contain the same eight work URLs and exactly one preview per entry. Every local image path exists. `git diff --check` passes. Existing screenshot assets are reused without modification.

## Sunjing preview

![Sunjing](https://raw.githubusercontent.com/MartinDelophy/awesome-gpt-6-astra/main/assets/screenshots/sunjing-puzzles/gameplay.jpg)

Public demo: https://sunjing-puzzles.hp20230404.chatgpt.site

Sunjing was already added to the primary catalogs in PR #17; this change translates that entry. GPT-6 Astra attribution remains pending creator confirmation.
