### PR TITLE
Improve Apex Club citadel gatehouses and 3D pickups

### DIFF
--- a/works/apex-club/citadel-gate.js
+++ b/works/apex-club/citadel-gate.js
@@ -1,0 +1,76 @@
+import * as THREE from 'three';
+
+// Locally generated, seamless masonry: no remote texture dependency.
+function masonry(){
+ const c=document.createElement('canvas');c.width=c.height=512;const ctx=c.getContext('2d');
+ let seed=71;const random=()=>{seed=(seed*1664525+1013904223)>>>0;return seed/4294967296;};
+ ctx.fillStyle='#343833';ctx.fillRect(0,0,512,512);
+ for(let row=0;row<8;row++)for(let col=-1;col<5;col++){
+  const x=col*128+(row%2)*64,y=row*64,v=82+Math.floor(random()*25);
+  ctx.fillStyle=`rgb(${v+5},${v+8},${v+4})`;ctx.fillRect(x+2,y+2,124,60);
+  ctx.fillStyle='rgba(219,216,190,.25)';ctx.fillRect(x+3,y+3,122,2);
+  ctx.fillStyle='rgba(10,18,15,.35)';ctx.fillRect(x+3,y+58,122,3);
+ }
+ for(let i=0;i<24000;i++){const v=random()>.5?200:15;ctx.fillStyle=`rgba(${v},${v},${v},.12)`;ctx.fillRect(random()*512,random()*512,1+random()*3,1);}
+ const map=new THREE.CanvasTexture(c);map.wrapS=map.wrapT=THREE.RepeatWrapping;map.colorSpace=THREE.SRGBColorSpace;map.anisotropy=4;
+ const bump=map.clone();bump.colorSpace=THREE.NoColorSpace;
+ return {map,bump};
+}
+export function createGateBuilder(){
+ const tex=masonry();
+ const stone=new THREE.MeshStandardMaterial({map:tex.map,bumpMap:tex.bump,bumpScale:.24,roughness:.94});
+ const trim=new THREE.MeshStandardMaterial({color:0xaaa38a,roughness:.86});
+ const wood=new THREE.MeshStandardMaterial({color:0x54251e,roughness:.78});
+ const dark=new THREE.MeshStandardMaterial({color:0x203132,roughness:.76});
+ const tile=new THREE.MeshStandardMaterial({color:0x465953,roughness:.58,metalness:.08});
+ const brass=new THREE.MeshStandardMaterial({color:0xb59a61,roughness:.42,metalness:.6});
+ const box=(g,mat,x,y,z,w,h,d)=>{const m=new THREE.Mesh(new THREE.BoxGeometry(w,h,d),mat);m.position.set(x,y,z);g.add(m);return m;};
+ function roof(g,width,depth,y){
+  // Curved barrel tiles sit above a solid eave; silhouette stays readable in motion.
+  box(g,dark,0,y,0,width*2,1.2,depth*2);
+  for(const sign of [-1,1]){
+   const vertices=[],indices=[];
+   for(let i=0;i<=10;i++){const t=i/10,h=y+9*(1-t)**1.6+1.5*t**8;vertices.push(-width,h,sign*t*depth,width,h,sign*t*depth);}
+   for(let i=0;i<10;i++){const a=i*2;indices.push(a,a+1,a+2,a+1,a+3,a+2);}
+   const geo=new THREE.BufferGeometry();geo.setAttribute('position',new THREE.Float32BufferAttribute(vertices,3));geo.setIndex(indices);geo.computeVertexNormals();
+   const mat=dark.clone();mat.side=THREE.DoubleSide;g.add(new THREE.Mesh(geo,mat));
+  }
+  for(const sign of [-1,1])for(let x=-width;x<=width;x+=1.6){
+   const pts=[];for(let i=0;i<=10;i++){const t=i/10;pts.push(new THREE.Vector3(x,y+9*(1-t)**1.6+1.5*t**8,sign*t*depth));}
+   const m=new THREE.Mesh(new THREE.TubeGeometry(new THREE.CatmullRomCurve3(pts),10,.48,5,false),tile);g.add(m);
+  }
+  box(g,brass,0,y+9,0,width*2+2,.7,.9);
+  for(const sign of [-1,1]){box(g,wood,0,y-1,sign*depth,width*2,1.1,1);for(let x=-width+2;x<width;x+=5){box(g,brass,x,y-2,sign*(depth-1),1,2,3);}}
+ }
+ return function buildGate(parent){
+  const gate=new THREE.Group();gate.name='Stone arch gatehouse';parent.add(gate);
+  // 68-unit clear opening exceeds the 64-unit driveable corridor, including at the arch spring.
+  const outline=new THREE.Shape();outline.moveTo(-46,-5);outline.lineTo(-34,-5);outline.lineTo(-34,14);
+  outline.absarc(0,14,34,Math.PI,0,true);outline.lineTo(34,-5);outline.lineTo(46,-5);outline.lineTo(46,62);outline.lineTo(-46,62);outline.closePath();
+  const geometry=new THREE.ExtrudeGeometry(outline,{depth:16,bevelEnabled:true,bevelSegments:2,steps:1,bevelSize:.35,bevelThickness:.35,curveSegments:32});
+  // Extrude UVs are world units; each repeat covers a 16 by 16 masonry patch.
+  const uv=geometry.attributes.uv;for(let i=0;i<uv.count;i++)uv.setXY(i,uv.getX(i)/16,uv.getY(i)/16);
+  const body=new THREE.Mesh(geometry,stone);body.position.z=-8;gate.add(body);
+  for(const z of [-8.6,8.6]){
+   for(let i=0;i<23;i++){
+    const a=i*Math.PI/23+.012,b=(i+1)*Math.PI/23-.012,s=new THREE.Shape();
+    s.moveTo(Math.cos(a)*34.5,14+Math.sin(a)*34.5);s.absarc(0,14,34.5,a,b,false);s.lineTo(Math.cos(b)*38,14+Math.sin(b)*38);s.absarc(0,14,38,b,a,true);s.closePath();
+    const m=new THREE.Mesh(new THREE.ExtrudeGeometry(s,{depth:.8,bevelEnabled:true,bevelSize:.12,bevelThickness:.12,bevelSegments:1,steps:1}),trim);m.position.z=z;gate.add(m);
+   }
+   for(const x of [-36.2,36.2])for(let y=1;y<14;y+=3.3)box(gate,trim,x,y,z,3.3,3.1,1);
+   box(gate,trim,0,60,z,94,2,2);
+  }
+  box(gate,trim,0,63,0,98,3,22);
+  for(const x of [-35,-21,-7,7,21,35])for(const z of [-7,7]){
+   box(gate,wood,x,73,z,1.8,18,1.8);box(gate,brass,x,65,z,2.5,1.2,2.5);
+  }
+  box(gate,wood,0,69,0,74,9,12);
+  for(const z of [-6.2,6.2])for(let x=-33;x<=33;x+=3)box(gate,brass,x,70,z,.24,7,.3);
+  roof(gate,43,14,81);roof(gate,30,10,93);
+  for(const z of [-9.4,9.4]){
+   box(gate,wood,0,55,z,18,5,1);box(gate,brass,0,57.5,z,18,.3,1.1);
+   for(const x of [-5,0,5])box(gate,brass,x,55,z+Math.sign(z)*.6,1.4,2,.3);
+  }
+  return gate;
+ };
+}

--- a/works/apex-club/game.js
+++ b/works/apex-club/game.js
@@ -1,3 +1,4 @@
+import {createPickupFactory} from './pickup-design.js';
 import {JUMP_RAMPS,RAMP_LENGTH,rampHeight,createStunts,offerDrift,stepStunts,boostOpportunity,fireStunt} from './stunt-model.js';
 import {createShowroom,createCitadel} from './scene-design.js';
 import {createMobileControls,isHandheldDevice} from './mobile-controls.js';
@@ -317,10 +318,10 @@ for(let i=0;i<7;i++){
 
 // pickups
 const pickups=[];
-const pickupColors={boost:0x20fff2,shield:0x875eff,weapon:0xff3d81};
+const makePickup=createPickupFactory();
 for(let i=0;i<30;i++){
   const type=['boost','shield','weapon'][i%3], t=(i/30+.025)%1, f=trackFrame(t), lane=(i%2?1:-1)*(10+Math.random()*20);
-  const m=new THREE.Mesh(new THREE.OctahedronGeometry(3.7,0),new THREE.MeshBasicMaterial({color:pickupColors[type],wireframe:true}));
+  const m=makePickup(type);
   m.position.copy(f.p).addScaledVector(f.side,lane).addScaledVector(f.normal,7); scene.add(m); pickups.push({m,type,t,lane,active:true,respawn:0});
 }
 
@@ -466,7 +467,7 @@ function updateCombat(dt){
 function updatePickups(dt,time){
   for(const p of pickups){
     if(!p.active){p.respawn-=dt;if(p.respawn<=0){p.active=true;p.m.visible=true}continue;}
-    p.m.rotation.x+=dt*2.2;p.m.rotation.y+=dt*3.7;p.m.scale.setScalar(1+Math.sin(time*5+p.t*30)*.18);
+    p.m.userData.animate(time+p.t*30,reducedMotion);
     let td=Math.abs(p.t-state.t);td=Math.min(td,1-td);
     if(td<.0028&&Math.abs(p.lane-state.lane)<9){
       p.active=false;p.m.visible=false;p.respawn=7;

--- a/works/apex-club/pickup-design.js
+++ b/works/apex-club/pickup-design.js
@@ -1,0 +1,35 @@
+import * as THREE from 'three';
+
+export function createPickupFactory(){
+ const metal=new THREE.MeshStandardMaterial({color:0x263647,metalness:.65,roughness:.32});
+ const silver=new THREE.MeshStandardMaterial({color:0xc9dae0,metalness:.55,roughness:.26});
+ const colors={boost:0x25ded3,shield:0x9876ff,weapon:0xff597f};
+ const materials=Object.fromEntries(Object.entries(colors).map(([type,color])=>[type,new THREE.MeshStandardMaterial({color,emissive:color,emissiveIntensity:.35,metalness:.25,roughness:.28})]));
+ const geometries={tank:new THREE.CylinderGeometry(2,2,5.3,16),cap:new THREE.CylinderGeometry(2.15,2.15,.65,16),core:new THREE.SphereGeometry(2.1,16,12),ring:new THREE.TorusGeometry(2.9,.22,6,32)};
+ const add=(g,geo,mat,x=0,y=0,z=0)=>{const m=new THREE.Mesh(geo,mat);m.position.set(x,y,z);g.add(m);return m;};
+ function shieldGeometry(){const s=new THREE.Shape();s.moveTo(-2.8,2.8);s.lineTo(2.8,2.8);s.lineTo(2.5,-.5);s.quadraticCurveTo(1.8,-2.5,0,-3.5);s.quadraticCurveTo(-1.8,-2.5,-2.5,-.5);s.closePath();return new THREE.ExtrudeGeometry(s,{depth:.8,bevelEnabled:true,bevelThickness:.25,bevelSize:.25,bevelSegments:2,steps:1});}
+ const shield=shieldGeometry();
+ return function createPickup(type){
+  const group=new THREE.Group(),body=new THREE.Group(),accent=materials[type];group.add(body);group.name=`${type} collectible`;
+  if(type==='boost'){
+   add(body,geometries.tank,metal);
+   for(const y of [-2.6,2.6])add(body,geometries.cap,silver,0,y);
+   for(let i=0;i<4;i++){const a=i*Math.PI/2,m=add(body,new THREE.BoxGeometry(.65,3.5,.18),accent,Math.sin(a)*2,0,Math.cos(a)*2);m.rotation.y=a;}
+   add(body,new THREE.CylinderGeometry(.75,.75,1,12),metal,0,3.2);
+   const valve=add(body,new THREE.BoxGeometry(2,.35,.65),silver,0,3.7);valve.rotation.y=.4;
+  }else if(type==='shield'){
+   add(body,shield,silver,0,0,-.65);
+   const face=add(body,shield,accent,0,0,-.04);face.scale.set(.8,.8,1);
+   for(const z of [-.95,1.1]){add(body,new THREE.BoxGeometry(.5,3.1,.2),silver,0,.1,z);add(body,new THREE.BoxGeometry(2.1,.5,.2),silver,0,.4,z);}
+  }else{
+   add(body,geometries.core,accent);
+   for(let i=0;i<3;i++){const ring=add(body,geometries.ring,metal);ring.rotation.set(i*Math.PI/3,Math.PI/4,0);}
+   for(const y of [-2.7,2.7])add(body,new THREE.CylinderGeometry(.8,.8,.7,12),silver,0,y);
+  }
+  const halo=add(group,new THREE.TorusGeometry(4,.1,6,40),accent,0,-5.8);halo.rotation.x=Math.PI/2;
+  // Ground locator stays still while the collectible gently turns above it.
+  const disk=add(group,new THREE.CircleGeometry(3.9,32),new THREE.MeshBasicMaterial({color:colors[type],transparent:true,opacity:.09,depthWrite:false,side:THREE.DoubleSide}),0,-5.85);disk.rotation.x=-Math.PI/2;
+  group.userData.animate=(time,reduced)=>{body.rotation.y=reduced?.35:time*.7;body.position.y=reduced?0:Math.sin(time*2)*.4;};
+  return group;
+ };
+}

--- a/works/apex-club/scene-design.js
+++ b/works/apex-club/scene-design.js
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import {createGateBuilder} from './citadel-gate.js';
 
 export function createShowroom(){
  const scene=new THREE.Scene();scene.background=new THREE.Color('#080d17');scene.fog=new THREE.Fog('#080d17',65,180);
@@ -22,6 +23,7 @@ export function createShowroom(){
 
 export function createCitadel(trackFrame,trackLength){
  const group=new THREE.Group();group.name='Jade Citadel';
+ const buildGate=createGateBuilder();
  const stone=new THREE.MeshStandardMaterial({color:0x687474,roughness:.95});
  const cap=new THREE.MeshStandardMaterial({color:0xa4a18c,roughness:.9});
  const red=new THREE.MeshStandardMaterial({color:0x8e352a,roughness:.65});
@@ -59,7 +61,7 @@ export function createCitadel(trackFrame,trackLength){
    box(pavilion,red,0,7,0,16,12,19);box(pavilion,gold,0,13,10,13,2,.4);
    eaves(pavilion,19,19);eaves(pavilion,14,28);
   }
-  if(i%3===0){box(tower,red,0,38,0,96,6,7);box(tower,gold,0,42,0,99,1,8);}
+  if(i%3===0)buildGate(tower);
   for(const x of [-33,33]){
    box(tower,red,x,14,12,1,28,1);box(tower,gold,x,27,12,9,.7,1);
    const lantern=new THREE.Mesh(new THREE.SphereGeometry(3.2,10,8),glow);lantern.scale.y=1.35;lantern.position.set(x+(x<0?3:-3),23,12);tower.add(lantern);

--- a/works/apex-club/scripts/build.mjs
+++ b/works/apex-club/scripts/build.mjs
@@ -1,6 +1,6 @@
 import {mkdir,copyFile,cp,readFile,writeFile} from 'node:fs/promises';
 import {createHash} from 'node:crypto';
-const files=['stunt-model.js','scene-design.js','index.html','style.css','bootstrap.js','game.js','driver-studio.js','kart-catalog.js','race-rules.js','driving-model.js','race-effects.js','race-audio.js','armored-kart.js','garage.html','garage.js','garage.css','mobile-controls.js'];
+const files=['pickup-design.js','citadel-gate.js','stunt-model.js','scene-design.js','index.html','style.css','bootstrap.js','game.js','driver-studio.js','kart-catalog.js','race-rules.js','driving-model.js','race-effects.js','race-audio.js','armored-kart.js','garage.html','garage.js','garage.css','mobile-controls.js'];
 await mkdir('dist',{recursive:true});
 for(const file of files)await copyFile(file,`dist/${file}`);
 await cp('vendor','dist/vendor',{recursive:true});


### PR DESCRIPTION
Jade Citadel now has drive-through stone gatehouses with masonry bump textures, segmented arch stones, layered tiled roofs and timber details. Road collectibles now use distinct nitrogen canister, shield and EMP models with metal surfaces, emissive accents and ground locator rings. Their animation uses slow rotation and gentle hovering and respects reduced-motion settings.

The new modules are included in the static build. Pickup rewards, respawn timing and driving physics are unchanged.

Validation: 33 tests passed; static build and git diff --check passed. Inspected local rendered models and started a Citadel race. Physical mobile performance and a full race through every gate have not been verified.

Live demo: https://apex-club-racing.vercel.app/ (release 9d88c133dad2).

This updates the existing Apex Club entry; no new gallery entry is added.