### PR TITLE
docs: complete 37 missing entries across 10 translations

### DIFF
--- a/README.ar.md
+++ b/README.ar.md
@@ -6,7 +6,7 @@
 
 # Awesome GPT-6 Astra
 
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](CONTRIBUTING.md) [![LINUX DO](https://img.shields.io/badge/LINUX%20DO-Community-f0b73f?style=flat-square)](https://linux.do/) [![Cases: 49](https://img.shields.io/badge/Cases-49-58a6ff?style=flat-square)](https://astragames.aigccreative.com/)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](CONTRIBUTING.md) [![LINUX DO](https://img.shields.io/badge/LINUX%20DO-Community-f0b73f?style=flat-square)](https://linux.do/) [![Cases: 86](https://img.shields.io/badge/Cases-86-58a6ff?style=flat-square)](https://astragames.aigccreative.com/)
 
 **مجموعة من الألعاب الممتعة المصنوعة باستخدام GPT-6 Astra.**
 
@@ -24,7 +24,7 @@
 
 ## ابدأ من هنا
 
-استكشف **49 لعبة ومشروعًا تفاعليًا**: استراتيجية السيطرة على الأراضي في عصر الممالك الثلاث، ألغاز خشبية متشابكة وألغاز الكتل المنزلقة، دمج الفواكه المرنة، والطيران بزر واحد، والقتال على بساط سحري، والدفاع عن جزيرة بشبكة كهربائية، والبقاء في البرية، وصيد الأسماك تحت الماء وإدارة مطعم سوشي والزراعة على جزيرة، وسباقات الكارت على حلبة الخليج، وركوب الدراجة مع بجع على الساحل، وألعاب طاولة محوّلة إلى ألعاب ثلاثية الأبعاد، وOrbital Garden. انقر على اسم العمل لفتح اللعبة مباشرة في المتصفح.
+استكشف **86 لعبة ومشروعًا تفاعليًا**: استراتيجية السيطرة على الأراضي في عصر الممالك الثلاث، ألغاز خشبية متشابكة وألغاز الكتل المنزلقة، دمج الفواكه المرنة، ولعبة 2048 لبناء المدن بالتوليد الإجرائي، والطيران بزر واحد، والقتال على بساط سحري، ولعبة تصويب كثيفة الرصاص من خمس مراحل، والدفاع عن جزيرة بشبكة كهربائية، والبقاء في البرية، وصيد الأسماك تحت الماء وإدارة مطعم سوشي والزراعة على جزيرة، وسباقات الكارت على حلبة الخليج، وركوب الدراجة مع بجع على الساحل، وألعاب طاولة محوّلة إلى ألعاب ثلاثية الأبعاد، وتصميم ديكور المنازل ثلاثي الأبعاد، وOrbital Garden. انقر على اسم العمل لفتح اللعبة مباشرة في المتصفح.
 
 تحديث القائمة: **2026-09-12**. تستند معلومات استخدام النموذج إلى تصريحات المؤلفين أو مقدّمي الأعمال؛ وتُوضّح التفاصيل غير المؤكدة في كل بند. يشير هذا التاريخ إلى تحديث القائمة، وليس إلى إعادة اختبار جميع الألعاب.
 
@@ -112,6 +112,70 @@
   - GPT-6 Astra: [X](https://x.com/jumperz/status/2096600055301984738) — يذكر المؤلف استخدام Astra في تطوير هذا المشروع. [ملاحظات التحقق (بالإنجليزية)](assets/screenshots/cinderfall/SOURCE.md).
   - معاينة: ![Cinderfall · Fire, Shadow & Steel](assets/screenshots/cinderfall/gameplay.jpg)
 
+- **[Oz Breakdance](https://satriodewantono.com/breakdance/)** — اسحب أطراف راقص بفيزياء الدمية الرخوة إلى الأهداف المطابقة لكسب النقاط وإطالة جولة البريك دانس المحددة بوقت.
+  - المبدع: [Satrio](https://x.com/satrio_d)
+  - المنصة: متصفح على الحاسوب، وتحكم بالفأرة؛ بدأت جولة محددة بوقت دون تسجيل الدخول.
+  - GPT-6 Astra: [X](https://x.com/satrio_d/status/2096022866097758500) — يقول المبدع إن Astra حسّن لعبة البريك دانس الموجودة لديه وطريقة عرضها. [ملاحظات التحقق](assets/screenshots/breakdance/SOURCE.md).
+  - معاينة: ![راقص بفيزياء الدمية الرخوة يحاول بلوغ هدف بالقدم في ساحة بريك دانس مع مؤقت.](assets/screenshots/breakdance/gameplay.jpg)
+
+- **[Astral War](https://astralwar.io/)** — لعبة تصويب من منظور الشخص الأول في المتصفح بطابع الحرب العالمية الثانية، مع مظاهر جنود وزومبي، وتجهيزات أسلحة، وتدريب ضد الروبوتات وخيارات ردهة اللعب.
+  - المبدع: [Rishi](https://x.com/0xRishi)
+  - المنصة: متصفح على الحاسوب، ولوحة مفاتيح وفأرة؛ بدأ التدريب ضد الروبوتات دون تسجيل الدخول. لم يُختبر اللعب الجماعي أو دعم وحدات التحكم.
+  - GPT-6 Astra: [X](https://x.com/0xRishi/status/2096079660605997264) — يفيد Rishi بأنه صنع Astral War باستخدام Astra وThree.js وMeshy وElevenLabs. ويذكر الموقع الحالي Vesper أيضًا؛ راجع ملاحظة إسناد المساهمات. [ملاحظات التحقق](assets/screenshots/astral-war/SOURCE.md).
+  - معاينة: ![مشهد قتال جارٍ في Astral War مع السلاح وعناصر التحكم في ساحة المعركة.](assets/screenshots/astral-war/gameplay.jpg)
+
+- **[FLOP CLUB](https://bubucn.com/ai-model-evals/flop-club/game/index.html)** — اقفز إلى الماء من منصات بثلاثة ارتفاعات، ونفّذ شقلبات والتفافات، واستهدف حلقة عائمة لتحسين نقاط دخولك إلى الماء.
+  - المبدع: [BubuAi](https://x.com/BubuStd)
+  - المنصة: متصفح؛ تبدأ اللعبة في صفحتها المستقلة مباشرة دون تسجيل الدخول أو تنزيلات. بدأت قفزة أثناء تحقق 2026-09-09؛ تحكم بلوحة المفاتيح وتحكم باللمس موضح في الوثائق.
+  - GPT-6 Astra: [X](https://x.com/BubuStd/status/2096402783805354091) — يفيد المبدع بأنه أنشأ اللعبة بطلب واحد إلى Astra Pro باستخدام Three.js. [ملاحظات التحقق](assets/screenshots/flop-club/SOURCE.md).
+  - المصادر: [تقديم المشروع](https://bubucn.com/zh/ai-model-evals/flop-club)
+  - معاينة: ![غواص على المنصة المرتفعة فوق الحلقة المستهدفة وعناصر التحكم بالدخول إلى الماء.](assets/screenshots/flop-club/gameplay.jpg)
+
+- **[Vector Dive — Beyond the Signal](https://vector-dive.openai.chatgpt.site/)** — قد مركبتك عبر مسارات شبكية نيونية تتسارع مع كل دورة، واضبط توقيت التعزيز والحركة الطورية للبقاء مدة أطول.
+  - المبدع: [Thomas Ricouard](https://x.com/Dimillian)
+  - المنصة: متصفح على الحاسوب؛ بدأت رحلة تُحتسب فيها النقاط دون تسجيل الدخول. WASD للطيران وSpace للتعزيز وShift للحركة الطورية.
+  - GPT-6 Astra: [X](https://x.com/Dimillian/status/2097188900888322323) — يقول المبدع إن Astra أنشأ اللعبة وموسيقاها انطلاقًا من وصف بصري بأسلوب النيون والسينث ويف ورسوم تصورية. [ملاحظات التحقق](assets/screenshots/vector-dive/SOURCE.md).
+  - معاينة: ![مسار الطيران النيوني في Vector Dive مع مركبة اللاعب وواجهة اللعب.](assets/screenshots/vector-dive/gameplay.jpg)
+
+- **[Harbor Skirmish](https://gpt6astra-game.vercel.app/)** — دافع عن بلدة ساحلية من موجات الأرانب المشاغبة، مستخدمًا ثلاثة أسلحة ومسارات فوق الأسطح واندفاعات وخطافًا للتنقل.
+  - المبدع: [OpenDesign](https://x.com/OpenDesignHQ)
+  - المنصة: متصفح على الحاسوب؛ لوحة مفاتيح وفأرة، دون تسجيل الدخول أو تنزيلات.
+  - GPT-6 Astra: [تصريح المبدع](https://x.com/OpenDesignHQ/status/2097635757917983223) — تحدد OpenDesign هذه اللعبة المبنية بـThree.js بوصفها نسخة GPT-6 Astra ضمن مقارنتها بين نموذجين. [ملاحظات التحقق](assets/screenshots/harbor-skirmish/SOURCE.md).
+  - معاينة: ![منظور شخص أول ببندقية نحو بلدة Seabreeze، مع أرانب تقترب وعدّاد موجات وعناصر التحكم بالأسلحة.](assets/screenshots/harbor-skirmish/gameplay.jpg)
+
+- **[UNDERGROUND — Underground Boxing](https://iamsonic.net/2026/mini-games/underground-boxing.html)** — خض ثلاث جولات ملاكمة محددة بوقت في حلبة ثلاثية الأبعاد تحت الأرض، ووازن بين اللكم والصد والمراوغة والقدرة على التحمل.
+  - المبدع: [Sonic的奇思妙想](https://x.com/sonic0828)
+  - المنصة: متصفح على الحاسوب؛ WASD للحركة وJ/K للكم وL للصد وSpace للمراوغة؛ دون تسجيل الدخول أو تنزيلات.
+  - GPT-6 Astra: [تصريح المبدع](https://x.com/sonic0828/status/2097601232877781344) — يسمي المبدع GPT-6 Astra أداة إنشاء هذه الألعاب المصغرة في سلسلة عرض أعماله، ويضع رابط هذه النسخة في الرد الخاص بالملاكمة. [ملاحظات التحقق](assets/screenshots/underground-boxing/SOURCE.md).
+  - المصادر: [رابط الإصدار من المبدع](https://x.com/sonic0828/status/2097601584410796401)
+  - معاينة: ![ملاكمان يتبادلان الضربات في حلبة مضاءة تحت الأرض، مع مؤقت الجولة وأشرطة الصحة والتحمل.](assets/screenshots/underground-boxing/gameplay.jpg)
+
+- **[Urban Champion 3D](https://iamsonic.net/2026/mini-games/urban-champion.html)** — تبادل اللكمات العالية والمنخفضة في شارع عند الغروب، وصد الهجمات المضادة وادفع خصمك إلى فتحة الصرف بينما تتجنب أصص الزهور المتساقطة.
+  - المبدع: [Sonic的奇思妙想](https://x.com/sonic0828)
+  - المنصة: متصفح على الحاسوب؛ A/D للحركة وJ/K للكم وU/I للصد وSpace للمراوغة؛ دون تسجيل الدخول.
+  - GPT-6 Astra: [تصريح المبدع](https://x.com/sonic0828/status/2097601232877781344) — يتضمن عرض المبدع لأعمال GPT-6 Astra رد إصدار منفصلًا يربط بلعبة قتال الشوارع هذه. [ملاحظات التحقق](assets/screenshots/urban-champion-3d/SOURCE.md).
+  - المصادر: [رابط الإصدار من المبدع](https://x.com/sonic0828/status/2097601861658587376)
+  - معاينة: ![المقاتلان الأزرق والأحمر يتبادلان اللكمات أمام Sunset Mart، مع مؤقت الجولة وأشرطة التحمل.](assets/screenshots/urban-champion-3d/gameplay.jpg)
+
+- **[Zero District — Shells 3D](https://iamsonic.net/2026/mini-games/shells-3d/play.html)** — اصمد في حصار مدينة لثلاث دقائق بفضل إطلاق النار التلقائي والمراوغة بالحركة وجمع الخبرة واختيار الترقيات.
+  - المبدع: [Sonic的奇思妙想](https://x.com/sonic0828)
+  - المنصة: متصفح؛ الحركة عبر WASD أو السحب، والتصويب تلقائي؛ دون تسجيل الدخول أو تنزيلات.
+  - GPT-6 Astra: [تصريح المبدع](https://x.com/sonic0828/status/2097601232877781344) — يذكر المبدع GPT-6 Astra في إعلان المجموعة، ويربط بنسخة البقاء الثلاثية الأبعاد هذه في رد خاص بها. [ملاحظات التحقق](assets/screenshots/zero-district-shells-3d/SOURCE.md).
+  - المصادر: [رابط الإصدار من المبدع](https://x.com/sonic0828/status/2097602391122264310)
+  - معاينة: ![ناجٍ يطلق النار تلقائيًا على الأعداء المحيطين في شارع المدينة، مع 14 عدوًا مهزومًا و166 ثانية متبقية.](assets/screenshots/zero-district-shells-3d/gameplay.jpg)
+
+- **[ASCII DISTRICT](https://ascii-district.vercel.app/)** — قاتل موجات من أعداء فيروسات الحاسوب في ساحة بمنظور الشخص الأول مرسومة بمحارف ASCII، مع الركض والقفز والانزلاق.
+  - المبدع: [Acker Code](https://x.com/acker_code)
+  - المنصة: متصفح على الحاسوب؛ لوحة مفاتيح وفأرة، دون تسجيل الدخول. انقر الساحة لحجز مؤشر الفأرة، واضغط Esc لتحريره.
+  - GPT-6 Astra: [تصريح المبدع](https://x.com/acker_code/status/2097542957070975286) — ينسب المبدع صراحةً إنشاء لعبة التصويب بفن ASCII هذه إلى Codex وGPT-6 Astra. [ملاحظات التحقق](assets/screenshots/ascii-district/SOURCE.md).
+  - معاينة: ![فناء مرسوم بمحارف ASCII مع فيروسات تقترب وواجهة بندقية تعرض 29 طلقة بعد إطلاق النار.](assets/screenshots/ascii-district/gameplay.jpg)
+
+- **[Aura Farming: Unbothered](https://www.aigameshare.com/games/aura-farming-game)** — وازن كابيبارا راقصة على قارب تنين، ومل بجسمها في مواجهة الأمواج، وأكمل ست حركات قبل انتهاء مؤقت الأربعين ثانية.
+  - المبدع: [nilni / @nil](https://www.aigameshare.com/profile/nil)
+  - المنصة: متصفح على الحاسوب؛ لعب مجاني دون تسجيل الدخول. انقر Play؛ مزايا الحساب اختيارية.
+  - GPT-6 Astra: [صفحة اللعبة من المبدع](https://www.aigameshare.com/games/aura-farming-game) — يذكر المبدع GPT-6 Astra وCodex ضمن أدوات اللعبة، إلى جانب Blender وThree.js وImageGen وWebAudio. [ملاحظات التحقق](assets/screenshots/aura-farming/SOURCE.md).
+  - معاينة: ![كابيبارا ترقص على قارب تنين، مع تحكم بالميل والتثبيت وواجهة تحدي الحركات الست.](assets/screenshots/aura-farming/gameplay.jpg)
+
 <a id="puzzles"></a>
 
 ### الألغاز والتفكير
@@ -137,6 +201,25 @@
   - مشاركة النموذج: [سجل الإنشاء](works/sunjing-puzzles/CREATION.md) — عمل متتابع عبر Codex على تصميم اللعبة والرسوم ثلاثية الأبعاد المُولّدة إجرائيًا والقواعد وآلية الحل والاختبارات؛ الاستخدام المحدد لـ GPT-6 Astra بانتظار تأكيد المبدع (طلب مبدئي).
   - موارد التطوير: [الشفرة المصدرية وتعليمات التشغيل](works/sunjing-puzzles/README.md) · [المتطلبات](works/sunjing-puzzles/PROMPTS.md) · التقنيات: React, Vinext/Vite, Three.js.
   - معاينة: ![لغز Sunjing الخشبي من ست قطع على طاولة عمل خضراء ثلاثية الأبعاد، مع أرقام القطع وأدوات سحبها.](assets/screenshots/sunjing-puzzles/gameplay.jpg)
+
+- **[CityMaker](https://citymaker.0to1app.com)** — لغز 2048 على رقعة مدينة 4×4: ادمج المباني المتطابقة للتقدم عبر أحد عشر مستوى معماريًا في كل مدينة، من البيوت التقليدية إلى أفق معروف المعالم. تتوفر اثنتا عشرة مدينة وإمكانية تدوير المشهد 45° في كل مرة.
+  - المبدع: [Derek Wang](https://github.com/derek-wangpch)
+  - المنصة: متصفحات الحاسوب والهاتف الداعمة لـWebGL؛ الإنجليزية والصينية المبسطة والتقليدية. مجاني دون تسجيل الدخول أو مفتاح API؛ يُحفظ التقدم لكل مدينة في المتصفح الحالي، ويمكن تثبيت اللعبة على الشاشة الرئيسية في iOS.
+  - GPT-6 Astra: [سجل الإنشاء](https://github.com/derek-wangpch/OpenCityMaker/blob/master/docs/CREATION.md) — يفيد المبدع باستخدام GPT-6 Astra لإنشاء الهندسة الإجرائية لجميع نماذج المباني الـ132 عبر سير عمل يستند إلى المراجع: دراسة زوايا متعددة، وتشكيل الكتل بدءًا من الهيئة الخارجية، والتحقق بلقطات الشاشة؛ ولم يكن ذلك اختبارًا بطلب واحد.
+  - المصادر: [الشيفرة المصدرية والإعداد](https://github.com/derek-wangpch/OpenCityMaker) · [ملاحظات التحقق](https://github.com/derek-wangpch/OpenCityMaker/blob/master/QA.md) · التقنيات المستخدمة: React وTypeScript وVite وThree.js؛ جميع نماذج المباني البالغ عددها 132 هي هندسة إجرائية أصلية.
+  - معاينة: ![رقعة هونغ كونغ في CityMaker بمبانٍ ثلاثية الأبعاد قليلة المضلعات على شبكة 4×4، مع النقاط وشريط اختيار المدن والتحكم بالتدوير.](assets/screenshots/citymaker/gameplay.png)
+
+- **[Bonkshot](https://bonkshot.com/)** — اسحب المقلاع وأطلق شخصيات Bonker الصغيرة نحو الدعامات الخشبية لهدم المنشآت وإزالة الأهداف.
+  - المبدع: [edmund5](https://x.com/edmund5)
+  - المنصة: متصفح؛ اسحب للتصويب وأفلت للإطلاق. يمكن اللعب دون تسجيل الدخول؛ تسجيل الدخول عبر Google اختياري.
+  - GPT-6 Astra: [تصريح المبدع](https://x.com/edmund5/status/2097603093819261002) — يذكر المبدع GPT-6 Astra وThree.js لإنشاء اللعبة، مع موسيقى خلفية مصنوعة باستخدام Suno. [ملاحظات التحقق](assets/screenshots/bonkshot/SOURCE.md).
+  - معاينة: ![اللغز الأول في Grasslands بعد الإطلاق، مع برج خشبي منهار جزئيًا وهدف واحد متبقٍ و2,200 نقطة.](assets/screenshots/bonkshot/gameplay.jpg)
+
+- **[Greenhouse Escape Room: The Last Seed](https://www.aigameshare.com/games/greenhouse-escape-room)** — استكشف دفيئة مغلقة، وأصلح أنابيب المياه النحاسية، ورتب النباتات والضوء المنعكس، وأنقذ بذرتها الأخيرة.
+  - المبدع: [nilni / @nil](https://www.aigameshare.com/profile/nil)
+  - المنصة: متصفح؛ انقر Play ثم Begin. مجاني دون تسجيل الدخول؛ عناصر تحكم بالإنجليزية والصينية.
+  - GPT-6 Astra: [صفحة اللعبة من المبدع](https://www.aigameshare.com/games/greenhouse-escape-room) — يحدد المبدع GPT-6 Astra وCodex بوصفهما أدوات تطوير، إلى جانب ImageGen وWebAudio. [ملاحظات التحقق](assets/screenshots/greenhouse-escape-room/SOURCE.md).
+  - معاينة: ![غرفة Waterworks في لعبة الهروب من الدفيئة، مع جهاز أنابيب من تسع بلاطات ومؤقت ومخزون.](assets/screenshots/greenhouse-escape-room/gameplay.jpg)
 
 <a id="strategy-simulation"></a>
 
@@ -229,6 +312,24 @@
   - الموارد: [GitHub](https://github.com/LucasMarquesShiva/the-free-game)
   - معاينة: ![The Free Game](assets/screenshots/the-free-game/gameplay.jpg)
 
+- **[AGI of Empires — The Compute Wars](https://agiofempires.com/)** — اجمع التمويل ووحدات GPU، وابنِ مراكز بيانات وجيوشًا، وسابق مختبرات الذكاء الاصطناعي المنافسة نحو ASI أو دمر مقراتها.
+  - المبدع: [timour kosters](https://x.com/timourxyz)
+  - المنصة: متصفح على الحاسوب؛ لعبة استراتيجية ساخرة مجانية تجري في الزمن الحقيقي. جرى التحقق من بداية مباراة ضد الحاسوب وجمع الموارد دون تسجيل الدخول.
+  - GPT-6 Astra: [X](https://x.com/timourxyz/status/2096662786692776293) — يقول المبدع إنه طور هذه اللعبة المستوحاة من Age of Empires باستخدام Astra خلال يومين. [ملاحظات التحقق](assets/screenshots/agi-of-empires/SOURCE.md).
+  - معاينة: ![ساحة معركة AGI of Empires وعدّادات الموارد والمقر الرئيسي.](assets/screenshots/agi-of-empires/gameplay.jpg)
+
+- **[Atlas Go](https://atlas-go.borisxp.chatgpt.site/)** — العب غو على شبكات شوارع ورقع ذات رسوم بيانية غير مألوفة، مع خيارات للتناوب على الجهاز نفسه واللعب مع الأصدقاء.
+  - المبدع: [Boris Power](https://x.com/BorisMPower)
+  - المنصة: متصفح؛ فُتحت الرقعة المحلية دون تسجيل الدخول. لم تُختبر مباريات الأصدقاء عبر الإنترنت.
+  - GPT-6 Astra: [X](https://x.com/BorisMPower/status/2096784808399843582) — يصف المبدع لعبة غو الجماعية على رسوم بيانية اعتباطية هذه بأنها نتاج طلب واحد إلى Astra. [ملاحظات التحقق](assets/screenshots/atlas-go/SOURCE.md).
+  - معاينة: ![أحجار سوداء وبيضاء على رقعة Atlas Go ذات الرسم البياني الشبيه بخلايا النحل.](assets/screenshots/atlas-go/gameplay.jpg)
+
+- **[Ironwood — The Art of Industry](https://ironwood.sparkles.dev/)** — اجمع المواد الخام، وشغّل الآلات بالطاقة، ووصل السيور الناقلة لتحويل مساحة خالية إلى مصنع يعمل.
+  - المبدع: [Dan](https://x.com/aidaniil)
+  - المنصة: متصفح على الحاسوب؛ يفتح تدريب الضيف دون تسجيل الدخول، لكن حفظ التقدم يتطلب الدخول إلى حساب. لم يُختبر اللعب الجماعي بصورة مستقلة.
+  - GPT-6 Astra: [X](https://x.com/aidaniil/status/2096426970930106530) — يقول المبدع إنه وأخوه صنعاها باستخدام Astra وBlender MCP وCloudflare Durable Objects، بإلهام من Satisfactory وBesiege. [ملاحظات التحقق](assets/screenshots/ironwood/SOURCE.md).
+  - معاينة: ![آلات مصنع Ironwood والسيور الناقلة وتدريب إدارة الموارد.](assets/screenshots/ironwood/gameplay.jpg)
+
 - **[DUST FRONT](https://dust-front.mustafaakin.dev/)** — لعبة استراتيجية آنية فردية لبناء القاعدة والسيطرة على المواقع وقيادة القوات البرية والجوية.
   - المؤلف: [Mustafa Akın](https://x.com/mustafaakin)
   - المنصة: متصفح سطح المكتب؛ لوحة مفاتيح وفأرة، دون تسجيل دخول إلزامي.
@@ -241,6 +342,18 @@
   - GPT-6 Astra: [X](https://x.com/HDLhN783wtLkpPR/status/2097321360641122393) — يذكر المبدع في المنشور المرتبط أنه استخدم «GPT Astra» لإنشاء هذه اللعبة الاستراتيجية الآنية؛ لم يحدد إصدار النموذج بدقة أو خطوات التطوير بالتفصيل.
   - مراجع: [المشاركة](https://github.com/MartinDelophy/awesome-gpt-6-astra/issues/66) · [ملاحظات التحقق (بالإنجليزية)](assets/screenshots/frontline-command/SOURCE.md)
   - معاينة: ![Frontline Command: قاعدة وثلاث دبابات محددة ووضع محطة طاقة أثناء المباراة؛ v0.8، التُقطت في 2026-09-09.](assets/screenshots/frontline-command/gameplay.jpg)
+
+- **[Coin Pusher Roguelite: Mintfall](https://www.aigameshare.com/games/coin-pusher-roguelite-mintfall)** — صوّب في آلة دفع عملات ثلاثية الأبعاد، وادمج العملات الخاصة والآثار، واجتز ست جولات بعدد إسقاطات محدود وأهداف للنقاط.
+  - المبدع: [nilni / @nil](https://www.aigameshare.com/profile/nil)
+  - المنصة: متصفح؛ انقر Play، واللعب مجاني دون تسجيل الدخول. الحفظ عبر الحساب اختياري.
+  - GPT-6 Astra: [صفحة اللعبة من المبدع](https://www.aigameshare.com/games/coin-pusher-roguelite-mintfall) — يذكر المبدع GPT-6 Astra مع GPT-5.6 Sol وCodex، ولا تفصل صفحة اللعبة بين مساهماتهم. [ملاحظات التحقق](assets/screenshots/mintfall/SOURCE.md).
+  - معاينة: ![صينية العملات الثلاثية الأبعاد في الجولة الأولى من Mintfall، مع 33 نقطة و44 إسقاطًا وعناصر التحكم بالعملات الخاصة.](assets/screenshots/mintfall/gameplay.jpg)
+
+- **[Westward — The Oregon Trail](https://biswaz.me/westward/)** — قد قافلة عربة غربًا، وقنّن الطعام، وأدر الإصلاحات والصيد، واتخذ قرارات على طول مسار أوريغون.
+  - المبدع: [Biswas](https://x.com/bis_waz)
+  - المنصة: متصفح على الحاسوب؛ ابدأ بالمجموعة الخيالية المتاحة، دون تسجيل الدخول أو تثبيت.
+  - GPT-6 Astra: [X](https://x.com/bis_waz/status/2098023593468907747) — يقول Biswas إنه استخدم GPT-6 Astra لبناء هذه النسخة الحديثة الثلاثية الأبعاد من The Oregon Trail، ويضع رابط اللعبة القابلة للعب. [ملاحظات التحقق](assets/screenshots/westward/SOURCE.md).
+  - معاينة: ![عربة وثيران على الطريق إلى Kansas River، مع مسافة مقطوعة تبلغ 25 ميلًا ولوحة مؤن الرحلة.](assets/screenshots/westward/gameplay.jpg)
 
 <a id="rpg-adventures"></a>
 
@@ -278,6 +391,63 @@
   - المنصة: متصفح سطح المكتب؛ فُتح دون تسجيل دخول أو دفع. لم يُختبر على الهاتف.
   - GPT-6 Astra: [X](https://x.com/emollick/status/2096047660662722620) — يذكر المؤلف استخدام Astra في تطوير هذا المشروع. [ملاحظات التحقق (بالإنجليزية)](assets/screenshots/zork/SOURCE.md).
   - معاينة: ![Zork · The Great Underground Empire](assets/screenshots/zork/gameplay.jpg)
+
+- **[The Simpsons: Hit & Run — Browser Recreation](https://vheissu.github.io/hit-and-run-web/)** — استكشف Springfield سيرًا وبالسيارة في إعادة إنشاء غير رسمية للمتصفح، مع مهام وحركة مرور ومطاردات شرطة.
+  - المبدع: [Dwayne](https://x.com/CtrlAltDwayne)
+  - المنصة: متصفح على الحاسوب؛ حُمّلت المهمة الأولى دون تسجيل الدخول بعد تحميل أولي كبير للأصول. لم يُختبر إكمال الحملة كاملةً.
+  - GPT-6 Astra: [X](https://x.com/CtrlAltDwayne/status/2096872309936287887) — يصف المبدع إعادة بناء اللعبة للويب باستخدام GPT-6 Astra؛ ويذكر المستودع أيضًا مساعدة Claude في التحميل. تبقى حقوق أصول اللعبة الأصلية لأصحابها. [ملاحظات التحقق](assets/screenshots/hit-and-run-web/SOURCE.md).
+  - المصادر: [الشيفرة المصدرية والإعداد](https://github.com/Vheissu/hit-and-run-web)
+  - معاينة: ![Homer في Springfield مع هدف المهمة الأولى والخريطة المصغرة ظاهرين.](assets/screenshots/hit-and-run-web/gameplay.jpg)
+
+- **[Where the Wind Wanders](https://app.usecrayon.ai/play/a9a3c165-74b3-4ff6-9588-ad97f829ddb5)** — تجول في وادٍ مشمس بأسلوب 2.5D، واتبع المسارات واجمع ثلاث رسائل ريح في مغامرة استكشاف هادئة.
+  - المبدع: [Tushar](https://x.com/TusharXo)
+  - المنصة: متصفح، مستضافة على Crayon؛ جرى فحص صفحة اللعبة العامة والمشغّل المضمّن.
+  - GPT-6 Astra: [X](https://x.com/TusharXo/status/2096037482739683574) — يصف Tushar توليد Astra للمسارات والأصول؛ ويعلن منشور لاحق الإصدار القابل للعب باستخدام Astra وThree.js وCrayon. [ملاحظات التحقق](assets/screenshots/crayon-adventure/SOURCE.md).
+  - المصادر: [إعلان الإصدار من المبدع](https://x.com/TusharXo/status/2096741535891251261)
+  - معاينة: ![شخصية تستكشف واديًا مليئًا بالزهور مع ظهور هدف رسائل الريح.](assets/screenshots/crayon-adventure/gameplay.jpg)
+
+- **[ALIBI — The Last Light](https://alibi-blackthorn-manor.vercel.app/)** — حقق في جريمة قتل داخل Blackthorn Manor بأسلوب الإشارة والنقر، وافحص المشاهد واتبع الأدلة لتحديد القاتل.
+  - المبدع: [Christos Antonopoulos](https://x.com/Christos_antono)
+  - المنصة: متصفح؛ فُتح مدخل القصر التفاعلي دون تسجيل الدخول. لم تُختبر المشاهد المولّدة اللاحقة بالكامل.
+  - GPT-6 Astra: [X](https://x.com/Christos_antono/status/2096435122669297892) — ينسب المبدع لعبة التحقيق التوليدية هذه إلى كل من GPT Astra وH3 Max. [ملاحظات التحقق](assets/screenshots/alibi-blackthorn-manor/SOURCE.md).
+  - معاينة: ![مدخل القصر مع باب قابل للنقر ونص بداية التحقيق.](assets/screenshots/alibi-blackthorn-manor/gameplay.jpg)
+
+- **[Skyward: The Gathering](https://edge-city-skyward-quests.vercel.app/)** — استكشف جزرًا عائمة، واقفز وحلّق بين تجمعاتها، وأنجز مهام سكانها.
+  - المبدع: [timour kosters](https://x.com/timourxyz)
+  - المنصة: متصفح على الحاسوب، ولوحة مفاتيح وفأرة؛ جرى فحص صفحة إصدار المهام وعناصر التحكم.
+  - GPT-6 Astra: [X](https://x.com/timourxyz/status/2096379521926840339) — يقول المبدع إن Astra بنى لعبة ثلاثية الأبعاد قابلة للعب تضم شخصيات غير لاعبة ومهام مستوحاة من مواقع Edge City. [ملاحظات التحقق](assets/screenshots/skyward-gathering/SOURCE.md).
+  - معاينة: ![منظر عام لجزر Skyward العائمة مع عناصر التحكم بالاستكشاف واليوميات.](assets/screenshots/skyward-gathering/gameplay.jpg)
+
+- **[Anna & Leo · The Starstone Adventure](https://anna-leo-starstone.vercel.app/)** — بدّل بين سحر Anna الموسيقي وقوى Leo الخارقة لإيقاظ زهور الألحان واستكشاف Wonder Garden.
+  - المبدع: [Dharma Utomo](https://x.com/dharmautomo)
+  - المنصة: متصفح؛ بدأت المهمة الافتتاحية دون تسجيل الدخول. WASD للحركة وSpace للقفز وE للقوة وTab لتبديل البطل.
+  - GPT-6 Astra: [X](https://x.com/dharmautomo/status/2096573649235091967) — يقول المبدع إن GPT-6 Astra ساعده في بناء المغامرة الثلاثية الأبعاد، ويشارك فيديو لأطفاله وهم يختبرون اللعب. [ملاحظات التحقق](assets/screenshots/anna-leo-starstone/SOURCE.md).
+  - معاينة: ![عالم مغامرة Anna وLeo الثلاثي الأبعاد وواجهة المهام.](assets/screenshots/anna-leo-starstone/gameplay.jpg)
+
+- **[The Legend of Deller](https://rain-court-js.umodeler-inc-4323.chatgpt.site/)** — استكشف Rainmist Haven وتوجه إلى الدهاليز باستخدام سلاسل ضربات السيف ومهارات العناصر وحركات المراوغة.
+  - المبدع: [UModeler X PicoBerry](https://x.com/UModeler)
+  - المنصة: متصفح على الحاسوب؛ لوحة مفاتيح وفأرة، دون تسجيل الدخول. انتظر اكتمال التحميل الأولي للأصول الثلاثية الأبعاد.
+  - GPT-6 Astra: [تصريح المبدع](https://x.com/UModeler/status/2097792348407099553) — يقول المبدع إن PicoBerry ولّد الأصول، وإن GPT-6 Astra بنى حولها لعبة تقمص أدوار حركية باستخدام Three.js. [ملاحظات التحقق](assets/screenshots/the-legend-of-deller/SOURCE.md).
+  - المصادر: [رابط الإصدار من المبدع](https://x.com/UModeler/status/2097792351129178451)
+  - معاينة: ![Deller يراوغ بجوار نافورة وأكشاك السوق في Rainmist Haven، مع الصحة والمانا وعناصر التحكم بالمهارات.](assets/screenshots/the-legend-of-deller/gameplay.jpg)
+
+- **[Dungeon of Astra](https://wavedash.com/games/dungeon-of-astra)** — جنّد فريقًا وانزل إلى دهليز من مئة طابق، وامزج ضربات السيف وكرات النار وأدوار الرفاق في جولة ذات موت دائم.
+  - المبدع: [tonysuri / @tonysurix](https://x.com/tonysurix)
+  - المنصة: متصفح على الحاسوب عبر Wavedash؛ تبدأ اللعبة الأساسية دون تسجيل الدخول. تتوفر حسابات اختيارية وفتح مبكر للشخصيات مقابل الدفع.
+  - GPT-6 Astra: [تصريح المبدع](https://x.com/tonysurix/status/2097873333551616355) — يقول المبدع صراحةً إن لعبة استكشاف الدهاليز بفريق هذه أُنشئت باستخدام GPT-6 Astra. [ملاحظات التحقق](assets/screenshots/dungeon-of-astra/SOURCE.md).
+  - معاينة: ![البطل وفارس مستأجر يستخدمان كرة نار في الطابق الأول من الدهليز، مع صحة الفريق وخريطة مصغرة.](assets/screenshots/dungeon-of-astra/gameplay.jpg)
+
+- **[Sunlandia — The Forgotten Shore](https://sunlandia.smallweblab.com/)** — استكشف جزيرة بعد تحطم سفينة، وابحث عن الأدلة بمنظور الشخص الأول، وحل ألغاز البيئة في طريقك إلى المنارة.
+  - المبدع: [Ramon Linares / Small Web Lab](https://github.com/RamonLinares)
+  - المنصة: متصفح على الحاسوب؛ انتظر ظهور الجزيرة ثم اختر Begin expedition. مجاني دون حساب أو تثبيت.
+  - GPT-6 Astra: [يوميات تطوير المبدع](https://smallweblab.com/posts/sunlandia/) — بدأ المبدع باستخدام GPT-5.6 Sol، واستعان بـFable، وأكمل اللعبة باستخدام GPT-6 Astra. [ملاحظات التحقق](assets/screenshots/sunlandia/SOURCE.md).
+  - معاينة: ![شاطئ Sunlandia بمنظور الشخص الأول، مع الحطام والرصيف المكسور وهدف البحث عن مساعدة.](assets/screenshots/sunlandia/gameplay.jpg)
+
+- **[NÁCAR](https://nacar-microcosmo.preda2005.chatgpt.site/)** — أنمِ كائنًا مجهريًا داخل صدفة حلزون مغمورة بالماء، واجمع المغذيات وطوّر أجزاء جديدة من جسمه أثناء الاستكشاف.
+  - المبدع: [Marcio Lima / @Preda2005](https://x.com/Preda2005)
+  - المنصة: متصفح؛ نسخة تجريبية مجانية دون تسجيل الدخول، مع خمس لغات للواجهة منها الصينية.
+  - GPT-6 Astra: [سلسلة منشورات المبدع](https://x.com/Preda2005/status/2097954217180921928) — يقول Marcio إنه شرح فكرة تطور الكائنات هذه لـGPT-6 Astra، ثم طورها إلى النسخة التجريبية المرتبطة. [ملاحظات التحقق](assets/screenshots/nacar/SOURCE.md).
+  - معاينة: ![خلية صغيرة بين مغذيات ملونة، مع الكتلة الحيوية والتطور والمخزون وعناصر التحكم بالمياه المستكشفة.](assets/screenshots/nacar/gameplay.jpg)
 
 <a id="platformers-racing"></a>
 
@@ -343,6 +513,31 @@
   - GPT-6 Astra: [Issue #51](https://github.com/MartinDelophy/awesome-gpt-6-astra/issues/51) — بحسب المنشئ: الإصدار الأول باستخدام Qwen3.8 Max، والثاني أعيد بناؤه بالكامل باستخدام Astra.
   - معاينة: ![疾风赛道 / Kart Racing（跑跑卡丁车）](https://github.com/user-attachments/assets/015e0ca1-7032-4d0e-9391-ad3f40d84227)
 
+- **[TIDAL RUSH — Paradise GP](https://tidal-rush-paradise-gp.skirano.chatgpt.site/)** — انجرف بالكارت على حلبة استوائية، واستخدم الأدوات ونافس سبعة خصوم عبر ثلاث لفات.
+  - المبدع: [Pietro Schirano](https://x.com/skirano)
+  - المنصة: متصفح؛ بدأ السباق المكوّن من ثلاث لفات دون تسجيل الدخول. تحكم بلوحة المفاتيح للقيادة والانجراف والأدوات، إضافة إلى أزرار لمس على الشاشة.
+  - GPT-6 Astra: [توثيق استخدام النموذج](https://openai.com/index/gpt-6-astra/) — تربط صفحة إطلاق Astra لدى OpenAI بلعبة الكارت التفاعلية هذه وتنسبها إلى Pietro Schirano. منشور التعريف على X مشاركة من المجتمع وليس منشورًا للمبدع نفسه. [ملاحظات التحقق](assets/screenshots/tidal-rush/SOURCE.md).
+  - المصادر: [منشور التعريف باللعبة على X](https://x.com/alexgetmancom/status/2095598460921614825)
+  - معاينة: ![حلبة الكارت الاستوائية في Tidal Rush مع المركز في السباق وعناصر التحكم بالانجراف.](assets/screenshots/tidal-rush/gameplay.jpg)
+
+- **[LUNA — Crimson Requiem / 紅月のレクイエム](https://luna-crimson-requiem.ponsuke.chatgpt.site/)** — اقفز عبر مرحلة بفن بكسل قوطي، واضرب الأعداء بالسلاح أو اقفز عليهم لسحقهم أو استدعِ هجومًا في مغامرة قصيرة ذات تمرير جانبي.
+  - المبدع: [音羽ぽんすけ](https://x.com/ponsuke_otowa)
+  - المنصة: متصفح بواجهة يابانية؛ تحكم بلوحة المفاتيح ودعم للهواتف الذكية وفقًا للمبدع. تتوفر مرحلة واحدة.
+  - GPT-6 Astra: [X](https://x.com/ponsuke_otowa/status/2096531744933425299) — يفيد المبدع بنحو 25 دقيقة من التطوير باستخدام Astra وتصحيح واحد لحركة المشي؛ وينسب الموسيقى بصورة منفصلة إلى Suno. [ملاحظات التحقق](assets/screenshots/luna-crimson-requiem/SOURCE.md).
+  - معاينة: ![LUNA تقاتل في شارع قوطي تحت قمر أحمر، مع مؤشري الصحة والاستدعاء.](assets/screenshots/luna-crimson-requiem/gameplay.jpg)
+
+- **[Strange Orbit](https://app.usecrayon.ai/play/47df78e2-1410-45d1-833c-196e1161c0b8)** — سابق راكبي دراجات من رواد الفضاء حول حلقات كوكب، واجمع غبار النجوم واستفد من السير خلف المنافسين لتقليل مقاومة الهواء ثم اندفع في Orbital Cup.
+  - المبدع: [Crayon](https://x.com/usecrayon)
+  - المنصة: متصفح على Crayon؛ تحكم بلوحة المفاتيح وتحكم باللمس موضح في الوثائق. تعرض الصفحة العامة أوضاع السباق والتحدي الزمني والتجوال بلا نهاية.
+  - GPT-6 Astra: [X](https://x.com/usecrayon/status/2097468975995302167) — تذكر Crayon استخدام GPT-6 Astra وCrayon Pro وThree.js لإنشاء لعبة الدراجات الفضائية. [ملاحظات التحقق](assets/screenshots/crayon-space-bike/SOURCE.md).
+  - معاينة: ![رواد فضاء على دراجات يتسابقون على حلقة كوكبية، مع مؤشرات اللفة والمركز وغبار النجوم.](assets/screenshots/crayon-space-bike/gameplay.jpg)
+
+- **[One More Vine — Into the Wild](https://onemorevine.bennash.dev/)** — اركض واقفز وتأرجح عبر أربعة مستويات في الأدغال، واجمع الكنوز وتجنب التماسيح مع تحسين زمنك.
+  - المبدع: [Ben Nash](https://x.com/bennash)
+  - المنصة: متصفح، مع لوحة مفاتيح وعناصر حركة على الشاشة؛ حُمّل المستوى الأول والتعليمات دون تسجيل الدخول.
+  - GPT-6 Astra: [X](https://x.com/bennash/status/2096282758930645170) — يسميها المبدع صراحةً لعبة من أربعة مستويات مستوحاة من Pitfall ومصنوعة باستخدام GPT-6 Astra. [ملاحظات التحقق](assets/screenshots/one-more-vine/SOURCE.md).
+  - معاينة: ![مستوى منصات في الأدغال مع كروم متدلية وكنوز وحفر وتماسيح.](assets/screenshots/one-more-vine/gameplay.jpg)
+
 - **[混合马里奥Ⅱ · 忍者龙剑传 × 坦克大战 / Mario Mix II](https://aha-xiaoq.github.io/games/mario-mix-2/play.html)** — خض العالم السفلي 1-2 من Mario بشخصية Ryu Hayabusa من Ninja Gaiden ودبابة Battle City: اقفز وتسلّق الجدران وقاتل بمنظور جانبي مع ريو، أو قاتل بمنظور علوي بالدبابة، أو أنقذ الأميرة بتتابع يبدأ بالنينجا ثم ينتقل إلى الدبابة.
   - المبدع: [在下_小Q（Aha-xiaoQ）](https://github.com/Aha-xiaoQ)
   - المنصة: متصفح على الكمبيوتر، بواجهة صينية، وتُوصى لوحة المفاتيح؛ مجاني ولا يتطلب تسجيل الدخول أو التثبيت.
@@ -351,6 +546,37 @@
   - الحقوق: لعبة معجبين غير رسمية؛ تظل حقوق الشخصيات والصور والموسيقى الكلاسيكية لأصحابها. راجع نسب المواد في صفحة اللعبة الأصلية.
   - معاينة: ![Mario Mix II — غلاف فيديو قدّمه المبدع، وليس لقطة من اللعب.](https://aha-xiaoq.github.io/games/mario-mix-2/cover.jpg)
   - لقطة شاشة: ![دبابة Mario Mix II تطلق النار عند مدخل العالم 1-2؛ الإصدار 1.0 أثناء التشغيل، التُقطت في 2026-09-09.](assets/screenshots/mario-mix-2/gameplay.jpg)
+
+- **[Bengaluru ORR Rush](https://orr-rush-bengaluru.ravitheja.chatgpt.site/)** — سابق وسط حركة مرور Bengaluru، وتفادَ الحفر ودراجات التوصيل، واستخدم التعزيز أو التأرجح الجانبي لفتح مساحة.
+  - المبدع: [Ravi Theja](https://x.com/ravithejads)
+  - المنصة: متصفح على الحاسوب؛ تحكم بلوحة المفاتيح مع خيار تسارع تلقائي، دون تسجيل الدخول.
+  - GPT-6 Astra: [تصريح المبدع](https://x.com/ravithejads/status/2097181044625887392) — ينسب المبدع لعبة سباق طرق Bengaluru إلى GPT-6 Astra. [ملاحظات التحقق](assets/screenshots/bengaluru-orr-rush/SOURCE.md).
+  - معاينة: ![سيارة اللاعب الزرقاء وسط مرور Bengaluru، مع المركز والسرعة والمؤقت وتلميحات التحكم.](assets/screenshots/bengaluru-orr-rush/gameplay.jpg)
+
+- **[SKICROSS — Alpine Downhill](https://iamsonic.net/2026/mini-games/skicross.html)** — نافس ثلاثة متزلجين في النزول من جبل، واجتز البوابات والعوائق وابقَ أمام الانهيار الثلجي.
+  - المبدع: [Sonic的奇思妙想](https://x.com/sonic0828)
+  - المنصة: متصفح على الحاسوب؛ A/D للتوجيه وSpace للقفز وShift للتعزيز؛ دون تسجيل الدخول أو تنزيلات.
+  - GPT-6 Astra: [تصريح المبدع](https://x.com/sonic0828/status/2097601232877781344) — ينسب المبدع مجموعة الألعاب المصغرة إلى GPT-6 Astra ويقدم لعبة التزلج هذه في رد مخصص. [ملاحظات التحقق](assets/screenshots/skicross/SOURCE.md).
+  - المصادر: [رابط الإصدار من المبدع](https://x.com/sonic0828/status/2097601732297814300)
+  - معاينة: ![أربعة متزلجين على مسار ثلجي، مع مكافأة بوابة وترتيب السباق والسرعة ومؤشر المسافة إلى الانهيار.](assets/screenshots/skicross/gameplay.jpg)
+
+- **[Itsy Bitsy Spider · One More Climb](https://game-bench.piccini.app/games/gpt-6-astra/)** — تسلق جدارًا مغطى بالطحلب، واصطد الذباب لاستعادة قوة التمسك، واختبئ في فتحات المأوى قبل أن يجرف المطر العنكبوت.
+  - المبدع: [Luiz Piccini](https://piccini.app/)
+  - المنصة: متصفح؛ مجاني دون تسجيل الدخول. WASD أو عصا التحكم على الشاشة.
+  - GPT-6 Astra: [منصة Game Bench الخاصة بالمبدع](https://game-bench.piccini.app/) — تصنف Game Bench هذا العمل المنشور بأنه GPT-6 Astra canary، high، بتاريخ 2026-09-05، وقد أُنشئ انطلاقًا من وصف اللعبة المشترك لديها. [ملاحظات التحقق](assets/screenshots/itsy-bitsy-spider/SOURCE.md).
+  - معاينة: ![عنكبوت يتسلق جدارًا من الطوب المغطى بالطحلب على ارتفاع مترين، مع قوة التمسك والذباب ومأوى وعصا الحركة.](assets/screenshots/itsy-bitsy-spider/gameplay.jpg)
+
+- **[Desi Mayhem](https://desimayhem.com/)** — سابق بالدراجات النارية وسط مرور المدن الهندية، وتسلل بين الحافلات وعربات الريكشا الآلية مستخدمًا الركلات واللكمات والتعزيزات.
+  - المبدع: [Kishore](https://x.com/GetKishore)
+  - المنصة: متصفح على الحاسوب؛ مجاني دون حساب. اقبل لقب الراكب المولّد أو عدّله قبل الجولة الأولى.
+  - GPT-6 Astra: [سلسلة المبدع عن التطوير](https://x.com/GetKishore/status/2097906401159102811) — يصف Kishore تحسين اللعبة الثلاثية الأبعاد المبنية باستخدام Astra بالاستعانة بمراجع للشوارع واختبارات متكررة للمرور والاصطدامات وقتال السائقين. [ملاحظات التحقق](assets/screenshots/desi-mayhem/SOURCE.md).
+  - معاينة: ![سباق دراجات نارية في Chennai مع سائق اللاعب ومرور المدينة والخريطة المصغرة والمركز ومؤقت السباق.](assets/screenshots/desi-mayhem/gameplay.jpg)
+
+- **[Cosmic Tides](https://app.usecrayon.ai/play/362ae1e7-29bd-4fbc-9103-00649265d942)** — قد مركبة عبر محيط مجري، واتبع البوابات المتوهجة واختر سباقًا من لفتين أو انجرافًا لا ينتهي.
+  - المبدع: [Aniket J](https://x.com/aniketjart)
+  - المنصة: متصفح؛ انتظر الأصول الثلاثية الأبعاد ثم اختر Ride the current. مجاني دون تسجيل الدخول.
+  - GPT-6 Astra: [X](https://x.com/aniketjart/status/2098207146647433534) — يذكر Aniket استخدام GPT-6 Astra وBlender MCP وCrayon للعبة، ويصفها بتجربة مع خطط لمزيد من تحسين أسلوب اللعب. [ملاحظات التحقق](assets/screenshots/cosmic-tides/SOURCE.md).
+  - معاينة: ![سباق جارٍ في Cosmic Tides يقترب من بوابة متوهجة فوق بحر مجري، مع مؤشري اللفة والسرعة.](assets/screenshots/cosmic-tides/gameplay.jpg)
 
 <a id="experimental-multiplayer"></a>
 
@@ -396,6 +622,12 @@
   - المنصة: متصفح، مجانية، دون حساب. يذكر المنشئ احتمال الحاجة إلى VPN/وكيل. تم التحقق من بدء اللعب الفردي؛ لم يُختبر اللعب الجماعي.
   - GPT-6 Astra: [Issue #52](https://github.com/MartinDelophy/awesome-gpt-6-astra/issues/52) — بحسب المنشئ: الإصدار الأول باستخدام GPT-6 Astra Pro، ثم تحسينات باستخدام GPT-6 Astra في Codex.
   - معاينة: ![泡泡坦克大作战联机版 / Toon Tank Arena](https://github.com/user-attachments/assets/713d44f3-a77c-452c-ba6d-1231882dc670)
+
+- **[Above the Rooftops](https://app.usecrayon.ai/play/d09bb865-2259-42e2-86cc-fb609a9d6f28)** — لوّن طائرة ورقية وحلّق بها فوق أسطح المدينة، ووازن شد الخيط في طيران حر أو تحدٍ محدد بوقت لجمع أضواء السماء.
+  - المبدع: [Tushar / @TusharXo](https://x.com/TusharXo)
+  - المنصة: متصفح؛ اختر شخصية وادخل السطح ثم اختر Fly. مجاني دون تسجيل الدخول.
+  - GPT-6 Astra: [X](https://x.com/TusharXo/status/2098156783181467801) — ينسب Tushar صراحةً لعبة الطائرة الورقية المبنية بـThree.js إلى GPT-6 Astra وCrayon، ويذكر Images 2.5 للعناصر البصرية. [ملاحظات التحقق](assets/screenshots/above-the-rooftops/SOURCE.md).
+  - معاينة: ![تحدي طائرة ورقية فوق المدينة، مع الارتفاع وشد الخيط وتقدم جمع أضواء السماء وعناصر التوجيه.](assets/screenshots/above-the-rooftops/gameplay.jpg)
 
 ## ما الذي يتضمنه كل إدراج
 

--- a/README.de.md
+++ b/README.de.md
@@ -4,7 +4,7 @@
 
 # Awesome GPT-6 Astra
 
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](CONTRIBUTING.md) [![LINUX DO](https://img.shields.io/badge/LINUX%20DO-Community-f0b73f?style=flat-square)](https://linux.do/) [![Cases: 49](https://img.shields.io/badge/Cases-49-58a6ff?style=flat-square)](https://astragames.aigccreative.com/)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](CONTRIBUTING.md) [![LINUX DO](https://img.shields.io/badge/LINUX%20DO-Community-f0b73f?style=flat-square)](https://linux.do/) [![Cases: 86](https://img.shields.io/badge/Cases-86-58a6ff?style=flat-square)](https://astragames.aigccreative.com/)
 
 **Eine Sammlung interessanter Spiele, die mit GPT-6 Astra entwickelt wurden.**
 
@@ -22,7 +22,7 @@ Diese Seite übersetzt die [englische README](README.md). Aktuelle Änderungen l
 
 ## Hier anfangen
 
-Entdecke **49 Spiele und interaktive Projekte**: Gebietsstrategie zur Zeit der Drei Reiche, Holz-Steckpuzzles und Schiebepuzzles lösen, weiche Früchte verschmelzen, mit einer Taste fliegen, auf einem fliegenden Teppich kämpfen, eine Insel mit einem Stromnetz verteidigen, in der Wildnis überleben, unter Wasser fischen, ein Sushi-Restaurant betreiben und eine Insel bewirtschaften, Kartrennen auf Bay Circuit, eine Küstenradtour mit einem Pelikan, Tischspielzeug als 3D-Spiele und Orbital Garden. Ein Klick auf einen Titel öffnet das Spiel direkt im Browser.
+Entdecke **86 Spiele und interaktive Projekte**: Gebietsstrategie zur Zeit der Drei Reiche, Holz-Steckpuzzles und Schiebepuzzles lösen, weiche Früchte verschmelzen, 2048 mit prozeduralem Städtebau, mit einer Taste fliegen, auf einem fliegenden Teppich kämpfen, ein Bullet-Hell-Shooter mit fünf Stufen, eine Insel mit einem Stromnetz verteidigen, in der Wildnis überleben, unter Wasser fischen, ein Sushi-Restaurant betreiben und eine Insel bewirtschaften, Kartrennen auf Bay Circuit, eine Küstenradtour mit einem Pelikan, Tischspielzeug als 3D-Spiele, 3D-Wohnraumgestaltung und Orbital Garden. Ein Klick auf einen Titel öffnet das Spiel direkt im Browser.
 
 Katalog aktualisiert: **2026-09-12**. Angaben zur Modellnutzung beruhen auf Aussagen der Ersteller oder Einreichenden; unbestätigte Details sind im jeweiligen Eintrag markiert. Das Datum bezeichnet die Katalogpflege, keinen erneuten Spieltest aller Spiele.
 
@@ -110,6 +110,70 @@ Shooter, Kampf-, Überlebens- und Rhythmusspiele sowie alles, was zu einer weite
   - GPT-6 Astra: [X](https://x.com/jumperz/status/2096600055301984738) — Der Entwickler nennt Astra als Werkzeug für die Entwicklung dieses Projekts. [Prüfnotizen (Englisch)](assets/screenshots/cinderfall/SOURCE.md).
   - Vorschau: ![Cinderfall · Fire, Shadow & Steel](assets/screenshots/cinderfall/gameplay.jpg)
 
+- **[Oz Breakdance](https://satriodewantono.com/breakdance/)** — Ziehe die Gliedmaßen eines Ragdoll-Tänzers in passende Zielmarkierungen, um Punkte zu sammeln und die zeitbegrenzte Breaking-Runde zu verlängern.
+  - Entwickler: [Satrio](https://x.com/satrio_d)
+  - Plattform: Desktop-Browser, Maussteuerung; eine Runde mit Zeitlimit wurde ohne Anmeldung gestartet.
+  - GPT-6 Astra: [X](https://x.com/satrio_d/status/2096022866097758500) — Der Entwickler sagt, Astra habe sein bestehendes Breakdance-Spiel und dessen Präsentation verbessert. [Prüfnotizen](assets/screenshots/breakdance/SOURCE.md).
+  - Vorschau: ![Ein Ragdoll-Tänzer zielt mit dem Fuß auf eine Markierung in der zeitbegrenzten Breakdance-Arena.](assets/screenshots/breakdance/gameplay.jpg)
+
+- **[Astral War](https://astralwar.io/)** — Ein Browser-Ego-Shooter im Zweiter-Weltkrieg-Stil mit Soldaten- und Zombie-Aussehen, Waffenausrüstung, Bot-Training und Lobby-Optionen.
+  - Entwickler: [Rishi](https://x.com/0xRishi)
+  - Plattform: Desktop-Browser, Tastatur und Maus; Bot-Training wurde ohne Anmeldung gestartet. Mehrspieler- und Controller-Unterstützung wurden nicht getestet.
+  - GPT-6 Astra: [X](https://x.com/0xRishi/status/2096079660605997264) — Rishi berichtet, Astral War mit Astra, Three.js, Meshy und ElevenLabs gebaut zu haben. Die aktuelle Website nennt auch Vesper; siehe Zuordnungsnotiz. [Prüfnotizen](assets/screenshots/astral-war/SOURCE.md).
+  - Vorschau: ![Laufende Kampfansicht von Astral War mit Waffe und Gefechtssteuerung.](assets/screenshots/astral-war/gameplay.jpg)
+
+- **[FLOP CLUB](https://bubucn.com/ai-model-evals/flop-club/game/index.html)** — Springe von drei Plattformhöhen, führe Saltos und Schrauben aus und ziele auf einen schwimmenden Ring, um deine Wertung beim Eintauchen zu verbessern.
+  - Entwickler: [BubuAi](https://x.com/BubuStd)
+  - Plattform: Browser; das eigenständige Spiel startet ohne Anmeldung oder Download. Beim Test am 2026-09-09 wurde ein Sprung begonnen; Tastatur und dokumentierte Touch-Steuerung.
+  - GPT-6 Astra: [X](https://x.com/BubuStd/status/2096402783805354091) — Der Entwickler berichtet von einem einzigen Prompt für Astra Pro und einer Umsetzung mit Three.js. [Prüfnotizen](assets/screenshots/flop-club/SOURCE.md).
+  - Ressourcen: [Projektvorstellung](https://bubucn.com/zh/ai-model-evals/flop-club)
+  - Vorschau: ![Ein Springer auf der hohen Plattform über Zielring und Eintauchsteuerung.](assets/screenshots/flop-club/gameplay.jpg)
+
+- **[Vector Dive — Beyond the Signal](https://vector-dive.openai.chatgpt.site/)** — Fliege durch neonfarbene Drahtgitterkurse, die mit jeder Schleife schneller werden, und setze Boosts und Phasenwechsel im richtigen Moment ein.
+  - Entwickler: [Thomas Ricouard](https://x.com/Dimillian)
+  - Plattform: Desktop-Browser; ein Flug mit Punktwertung wurde ohne Anmeldung gestartet. WASD zum Fliegen, Leertaste für Boost, Shift für Phasenwechsel.
+  - GPT-6 Astra: [X](https://x.com/Dimillian/status/2097188900888322323) — Der Entwickler sagt, Astra habe Spiel und Musik aus einer Neon-/Synthwave-Gestaltungsvorgabe und Konzeptbildern erstellt. [Prüfnotizen](assets/screenshots/vector-dive/SOURCE.md).
+  - Vorschau: ![Neon-Flugstrecke von Vector Dive mit Spielerschiff und Spielanzeigen.](assets/screenshots/vector-dive/gameplay.jpg)
+
+- **[Harbor Skirmish](https://gpt6astra-game.vercel.app/)** — Verteidige eine Küstenstadt gegen Wellen aufmüpfiger Kaninchen mit drei Waffen, Wegen über Dächer, schnellen Ausweichmanövern und einem Greifhaken.
+  - Entwickler: [OpenDesign](https://x.com/OpenDesignHQ)
+  - Plattform: Desktop-Browser; Tastatur und Maus, ohne Anmeldung oder Download.
+  - GPT-6 Astra: [Angaben des Entwicklers](https://x.com/OpenDesignHQ/status/2097635757917983223) — OpenDesign bezeichnet dieses Three.js-Spiel in seinem Vergleich zweier Modelle als GPT-6-Astra-Version. [Prüfnotizen](assets/screenshots/harbor-skirmish/SOURCE.md).
+  - Vorschau: ![Gewehransicht aus der Ich-Perspektive in Seabreeze, mit herannahenden Kaninchen, Wellenzähler und Waffensteuerung.](assets/screenshots/harbor-skirmish/gameplay.jpg)
+
+- **[UNDERGROUND — Underground Boxing](https://iamsonic.net/2026/mini-games/underground-boxing.html)** — Boxe drei Runden mit Zeitlimit in einem unterirdischen 3D-Ring und teile Schläge, Blocks, Ausweichmanöver und Ausdauer geschickt ein.
+  - Entwickler: [Sonic的奇思妙想](https://x.com/sonic0828)
+  - Plattform: Desktop-Browser; WASD zur Bewegung, J/K zum Schlagen, L zum Blocken und Leertaste zum Ausweichen; ohne Anmeldung oder Download.
+  - GPT-6 Astra: [Angaben des Entwicklers](https://x.com/sonic0828/status/2097601232877781344) — Der Vorstellungsthread nennt GPT-6 Astra als Werkzeug für die Minispiele; die Antwort zum Boxen verlinkt diese Version. [Prüfnotizen](assets/screenshots/underground-boxing/SOURCE.md).
+  - Ressourcen: [Veröffentlichungslink des Entwicklers](https://x.com/sonic0828/status/2097601584410796401)
+  - Vorschau: ![Zwei Boxer im beleuchteten unterirdischen Ring mit Rundenuhr, Lebens- und Ausdauerbalken.](assets/screenshots/underground-boxing/gameplay.jpg)
+
+- **[Urban Champion 3D](https://iamsonic.net/2026/mini-games/urban-champion.html)** — Setze hohe und tiefe Schläge auf einer Straße im Sonnenuntergang ein, blocke Gegenangriffe und dränge den Gegner in einen Kanalschacht, während Blumentöpfe herabfallen.
+  - Entwickler: [Sonic的奇思妙想](https://x.com/sonic0828)
+  - Plattform: Desktop-Browser; A/D zur Bewegung, J/K für Schläge, U/I für Blocks und Leertaste zum Ausweichen; ohne Anmeldung.
+  - GPT-6 Astra: [Angaben des Entwicklers](https://x.com/sonic0828/status/2097601232877781344) — Die GPT-6-Astra-Präsentation des Entwicklers enthält eine eigene Veröffentlichungsantwort mit Link zu diesem Straßenkampfspiel. [Prüfnotizen](assets/screenshots/urban-champion-3d/SOURCE.md).
+  - Ressourcen: [Veröffentlichungslink des Entwicklers](https://x.com/sonic0828/status/2097601861658587376)
+  - Vorschau: ![Blauer und roter Kämpfer vor Sunset Mart, mit Rundenuhr und Ausdauerbalken.](assets/screenshots/urban-champion-3d/gameplay.jpg)
+
+- **[Zero District — Shells 3D](https://iamsonic.net/2026/mini-games/shells-3d/play.html)** — Überstehe eine dreiminütige Stadtbelagerung mit automatischem Schießen, Ausweichen durch Bewegung, Erfahrungspunkten zum Einsammeln und wählbaren Verbesserungen.
+  - Entwickler: [Sonic的奇思妙想](https://x.com/sonic0828)
+  - Plattform: Browser; WASD oder Ziehen zur Bewegung, automatisches Zielen; ohne Anmeldung oder Download.
+  - GPT-6 Astra: [Angaben des Entwicklers](https://x.com/sonic0828/status/2097601232877781344) — Der Entwickler nennt GPT-6 Astra in der Sammlungsankündigung und verlinkt dieses 3D-Überlebensspiel in einer eigenen Antwort. [Prüfnotizen](assets/screenshots/zero-district-shells-3d/SOURCE.md).
+  - Ressourcen: [Veröffentlichungslink des Entwicklers](https://x.com/sonic0828/status/2097602391122264310)
+  - Vorschau: ![Ein Überlebender schießt automatisch auf umringende Gegner; 14 besiegte Gegner und 166 verbleibende Sekunden.](assets/screenshots/zero-district-shells-3d/gameplay.jpg)
+
+- **[ASCII DISTRICT](https://ascii-district.vercel.app/)** — Bekämpfe Wellen von Computerviren in einer Ego-Arena aus ASCII-Zeichen, mit Sprinten, Springen und Rutschen.
+  - Entwickler: [Acker Code](https://x.com/acker_code)
+  - Plattform: Desktop-Browser; Tastatur und Maus, ohne Anmeldung. Klicke auf die Arena, um die Maus einzufangen; Esc gibt sie frei.
+  - GPT-6 Astra: [Angaben des Entwicklers](https://x.com/acker_code/status/2097542957070975286) — Der Entwickler nennt ausdrücklich Codex und GPT-6 Astra als Werkzeuge für diesen ASCII-Shooter. [Prüfnotizen](assets/screenshots/ascii-district/SOURCE.md).
+  - Vorschau: ![ASCII-Innenhof mit näher kommenden Viren und Gewehranzeige mit 29 Schuss nach dem Feuern.](assets/screenshots/ascii-district/gameplay.jpg)
+
+- **[Aura Farming: Unbothered](https://www.aigameshare.com/games/aura-farming-game)** — Balanciere ein tanzendes Wasserschwein auf einem Drachenboot, neige dich gegen die Wellen und schaffe sechs Bewegungen innerhalb von 40 Sekunden.
+  - Entwickler: [nilni / @nil](https://www.aigameshare.com/profile/nil)
+  - Plattform: Desktop-Browser; kostenlos ohne Anmeldung. Play anklicken; Kontofunktionen sind optional.
+  - GPT-6 Astra: [Eintrag des Entwicklers](https://www.aigameshare.com/games/aura-farming-game) — Der Entwickler nennt GPT-6 Astra und Codex sowie Blender, Three.js, ImageGen und WebAudio. [Prüfnotizen](assets/screenshots/aura-farming/SOURCE.md).
+  - Vorschau: ![Tanzendes Wasserschwein auf einem Drachenboot mit Neigungs- und Abstützsteuerung sowie Sechs-Bewegungen-Aufgabe.](assets/screenshots/aura-farming/gameplay.jpg)
+
 <a id="puzzles"></a>
 
 ### Rätsel und Denkspiele
@@ -135,6 +199,25 @@ Logikrätsel, Physikaufgaben, Wortspiele und raffinierte kleine Mechaniken.
   - Modellbeteiligung: [Entstehungsbericht](works/sunjing-puzzles/CREATION.md) — Iterative Arbeit in Codex an Spieldesign, prozeduraler 3D-Grafik, Regeln, Lösungsalgorithmus und Tests; die genaue Nutzung von GPT-6 Astra muss noch vom Autor bestätigt werden (Entwurfseinreichung).
   - Materialien: [Quellcode und Startanleitung](works/sunjing-puzzles/README.md) · [Anforderungen](works/sunjing-puzzles/PROMPTS.md) · Technik: React, Vinext/Vite, Three.js.
   - Vorschau: ![Sunjings sechsteiliges Holzpuzzle auf einer grünen 3D-Werkbank mit nummerierten Teilen und Steuerelementen zum Herausziehen.](assets/screenshots/sunjing-puzzles/gameplay.jpg)
+
+- **[CityMaker](https://citymaker.0to1app.com)** — Ein 2048-Puzzle auf einem 4×4-Stadtblock: Verschmelze gleiche Gebäude über elf Architekturstufen je Stadt, von traditionellen Häusern bis zur erkennbaren Skyline, in zwölf Städten mit einer in 45°-Schritten drehbaren Ansicht.
+  - Entwickler: [Derek Wang](https://github.com/derek-wangpch)
+  - Plattform: Desktop- und Mobilbrowser mit WebGL; Englisch sowie vereinfachtes und traditionelles Chinesisch. Kostenlos, ohne Anmeldung oder API-Schlüssel; Fortschritt je Stadt im aktuellen Browser, Installation auf dem iOS-Home-Bildschirm möglich.
+  - GPT-6 Astra: [Entstehungsbericht](https://github.com/derek-wangpch/OpenCityMaker/blob/master/docs/CREATION.md) — Der Entwickler berichtet, GPT-6 Astra für die prozedurale Geometrie aller 132 Gebäude verwendet zu haben: referenzgestützte Mehransichtenrecherche, an Silhouetten orientierte Grundkörper und Screenshot-Prüfung; kein Ein-Prompt-Test.
+  - Ressourcen: [Quellcode und Einrichtung](https://github.com/derek-wangpch/OpenCityMaker) · [Prüfnotizen](https://github.com/derek-wangpch/OpenCityMaker/blob/master/QA.md) · Technik: React, TypeScript, Vite und Three.js; alle 132 Gebäudemodelle bestehen aus eigenständig erstellter prozeduraler Geometrie.
+  - Vorschau: ![Hongkonger CityMaker-Spielbrett mit Low-Poly-3D-Gebäuden auf 4×4-Feldern, Punkten, Stadtauswahl und Drehsteuerung.](assets/screenshots/citymaker/gameplay.png)
+
+- **[Bonkshot](https://bonkshot.com/)** — Spanne eine Schleuder und schieße kleine Bonkers gegen Holzstützen, um Konstruktionen einstürzen zu lassen und Ziele abzuräumen.
+  - Entwickler: [edmund5](https://x.com/edmund5)
+  - Plattform: Browser; zum Zielen ziehen und zum Abschuss loslassen. Ohne Anmeldung spielbar; Google-Anmeldung optional.
+  - GPT-6 Astra: [Angaben des Entwicklers](https://x.com/edmund5/status/2097603093819261002) — Der Entwickler nennt GPT-6 Astra und Three.js für das Spiel und Suno für die Hintergrundmusik. [Prüfnotizen](assets/screenshots/bonkshot/SOURCE.md).
+  - Vorschau: ![Erstes Grasslands-Puzzle nach einem Schuss: teilweise eingestürzter Holzturm, ein verbleibendes Ziel und 2.200 Punkte.](assets/screenshots/bonkshot/gameplay.jpg)
+
+- **[Greenhouse Escape Room: The Last Seed](https://www.aigameshare.com/games/greenhouse-escape-room)** — Erkunde ein verschlossenes Gewächshaus, repariere kupferne Wasserleitungen, ordne Pflanzen und reflektiertes Licht an und rette den letzten Samen.
+  - Entwickler: [nilni / @nil](https://www.aigameshare.com/profile/nil)
+  - Plattform: Browser; Play und anschließend Begin anklicken. Kostenlos, ohne Anmeldung; englische und chinesische Bedienelemente.
+  - GPT-6 Astra: [Eintrag des Entwicklers](https://www.aigameshare.com/games/greenhouse-escape-room) — Der Entwickler nennt GPT-6 Astra und Codex als Entwicklungswerkzeuge sowie ImageGen und WebAudio. [Prüfnotizen](assets/screenshots/greenhouse-escape-room/SOURCE.md).
+  - Vorschau: ![Waterworks-Raum des Gewächshaus-Escape-Spiels mit Neun-Felder-Rohrmechanismus, Uhr und Inventar.](assets/screenshots/greenhouse-escape-room/gameplay.jpg)
 
 <a id="strategy-simulation"></a>
 
@@ -227,6 +310,24 @@ Tower Defense, strategische Kartenspiele, Aufbau-, Management- und Simulationssp
   - Ressourcen: [GitHub](https://github.com/LucasMarquesShiva/the-free-game)
   - Vorschau: ![The Free Game](assets/screenshots/the-free-game/gameplay.jpg)
 
+- **[AGI of Empires — The Compute Wars](https://agiofempires.com/)** — Sammle Finanzierung und GPUs, baue Rechenzentren und Armeen und erreiche vor rivalisierenden KI-Laboren die ASI oder zerstöre ihre Hauptquartiere.
+  - Entwickler: [timour kosters](https://x.com/timourxyz)
+  - Plattform: Desktop-Browser; kostenloses satirisches Echtzeitstrategiespiel. Start gegen den Computer und Rohstoffsammlung wurden ohne Anmeldung geprüft.
+  - GPT-6 Astra: [X](https://x.com/timourxyz/status/2096662786692776293) — Der Entwickler sagt, er habe dieses von Age of Empires inspirierte Spiel mit Astra in zwei Tagen entwickelt. [Prüfnotizen](assets/screenshots/agi-of-empires/SOURCE.md).
+  - Vorschau: ![Schlachtfeld von AGI of Empires mit Ressourcenzählern und Hauptquartier.](assets/screenshots/agi-of-empires/gameplay.jpg)
+
+- **[Atlas Go](https://atlas-go.borisxp.chatgpt.site/)** — Spiele Go auf Straßennetzen und ungewöhnlichen Graphenbrettern, lokal abwechselnd am selben Gerät oder über Optionen für Freundespartien.
+  - Entwickler: [Boris Power](https://x.com/BorisMPower)
+  - Plattform: Browser; lokales Brett ohne Anmeldung geöffnet. Online-Partien mit Freunden wurden nicht getestet.
+  - GPT-6 Astra: [X](https://x.com/BorisMPower/status/2096784808399843582) — Der Entwickler beschreibt dieses Mehrspieler-Go auf beliebigen Graphen als mit einem einzigen Astra-Prompt erstellt. [Prüfnotizen](assets/screenshots/atlas-go/SOURCE.md).
+  - Vorschau: ![Schwarze und weiße Steine auf dem wabenförmigen Graphenbrett von Atlas Go.](assets/screenshots/atlas-go/gameplay.jpg)
+
+- **[Ironwood — The Art of Industry](https://ironwood.sparkles.dev/)** — Sammle Rohstoffe, versorge Maschinen mit Energie und verbinde Förderbänder, um aus einer Lichtung eine arbeitende Fabrik zu machen.
+  - Entwickler: [Dan](https://x.com/aidaniil)
+  - Plattform: Desktop-Browser; Gast-Tutorial ohne Anmeldung, Speichern erfordert jedoch eine Anmeldung. Mehrspielerbetrieb wurde nicht unabhängig getestet.
+  - GPT-6 Astra: [X](https://x.com/aidaniil/status/2096426970930106530) — Der Entwickler sagt, er und sein Bruder hätten das Spiel mit Astra, Blender MCP und Cloudflare Durable Objects gebaut, inspiriert von Satisfactory und Besiege. [Prüfnotizen](assets/screenshots/ironwood/SOURCE.md).
+  - Vorschau: ![Fabrikmaschinen, Förderbänder und Ressourcen-Tutorial von Ironwood.](assets/screenshots/ironwood/gameplay.jpg)
+
 - **[DUST FRONT](https://dust-front.mustafaakin.dev/)** — Ein Einzelspieler-RTS mit Basisbau, Eroberung von Stützpunkten und Boden- und Luftstreitkräften.
   - Entwickler: [Mustafa Akın](https://x.com/mustafaakin)
   - Plattform: Desktop-Browser; Tastatur und Maus, keine Anmeldung erforderlich.
@@ -239,6 +340,18 @@ Tower Defense, strategische Kartenspiele, Aufbau-, Management- und Simulationssp
   - GPT-6 Astra: [X](https://x.com/HDLhN783wtLkpPR/status/2097321360641122393) — Im verlinkten Beitrag nennt der Ersteller „GPT Astra“ als Werkzeug zur Erstellung dieses Echtzeitstrategiespiels; die genaue Modellversion und der detaillierte Entwicklungsablauf werden nicht angegeben.
   - Verweise: [Einreichung](https://github.com/MartinDelophy/awesome-gpt-6-astra/issues/66) · [Prüfnotizen (Englisch)](assets/screenshots/frontline-command/SOURCE.md)
   - Vorschau: ![Frontline Command: Basis, drei ausgewählte Panzer und Platzierung eines Kraftwerks in einer laufenden Partie; v0.8, aufgenommen am 2026-09-09.](assets/screenshots/frontline-command/gameplay.jpg)
+
+- **[Coin Pusher Roguelite: Mintfall](https://www.aigameshare.com/games/coin-pusher-roguelite-mintfall)** — Ziele mit einem 3D-Münzschieber, kombiniere Spezialmünzen und Relikte und schaffe sechs Runden mit begrenzten Einwürfen und Punktezielen.
+  - Entwickler: [nilni / @nil](https://www.aigameshare.com/profile/nil)
+  - Plattform: Browser; Play anklicken, kostenlos und ohne Anmeldung. Kontogebundene Spielstände sind optional.
+  - GPT-6 Astra: [Eintrag des Entwicklers](https://www.aigameshare.com/games/coin-pusher-roguelite-mintfall) — Der Entwickler nennt GPT-6 Astra zusammen mit GPT-5.6 Sol und Codex; der Eintrag trennt ihre Beiträge nicht auf. [Prüfnotizen](assets/screenshots/mintfall/SOURCE.md).
+  - Vorschau: ![Mintfalls 3D-Münzfläche in Runde 1 mit 33 Punkten, 44 Einwürfen und Spezialmünzen-Steuerung.](assets/screenshots/mintfall/gameplay.jpg)
+
+- **[Westward — The Oregon Trail](https://biswaz.me/westward/)** — Führe eine Wagengruppe nach Westen, rationiere Nahrung, organisiere Reparaturen und Jagd und triff Entscheidungen entlang des Oregon Trail.
+  - Entwickler: [Biswas](https://x.com/bis_waz)
+  - Plattform: Desktop-Browser; Start mit der vorgegebenen fiktiven Gruppe, ohne Anmeldung oder Installation.
+  - GPT-6 Astra: [X](https://x.com/bis_waz/status/2098023593468907747) — Biswas sagt, er habe diese moderne 3D-Version von The Oregon Trail mit GPT-6 Astra gebaut, und verlinkt das spielbare Ergebnis. [Prüfnotizen](assets/screenshots/westward/SOURCE.md).
+  - Vorschau: ![Wagen und Ochsen auf dem Weg zum Kansas River, mit 25 zurückgelegten Meilen und Vorratsübersicht.](assets/screenshots/westward/gameplay.jpg)
 
 <a id="rpg-adventures"></a>
 
@@ -276,6 +389,63 @@ Rollenspiele, Erkundung, erzählerische Abenteuer und interaktive Geschichten.
   - Plattform: Desktopbrowser; ohne Anmeldung oder Zahlung geöffnet. Mobil nicht getestet.
   - GPT-6 Astra: [X](https://x.com/emollick/status/2096047660662722620) — Der Entwickler nennt Astra als Werkzeug für die Entwicklung dieses Projekts. [Prüfnotizen (Englisch)](assets/screenshots/zork/SOURCE.md).
   - Vorschau: ![Zork · The Great Underground Empire](assets/screenshots/zork/gameplay.jpg)
+
+- **[The Simpsons: Hit & Run — Browser Recreation](https://vheissu.github.io/hit-and-run-web/)** — Erkunde Springfield zu Fuß und im Auto in einer inoffiziellen Browser-Neuauflage mit Missionen, Verkehr und Polizeiverfolgungen.
+  - Entwickler: [Dwayne](https://x.com/CtrlAltDwayne)
+  - Plattform: Desktop-Browser; erste Mission ohne Anmeldung nach umfangreichem anfänglichem Laden der Spielressourcen geöffnet. Die komplette Kampagne wurde nicht getestet.
+  - GPT-6 Astra: [X](https://x.com/CtrlAltDwayne/status/2096872309936287887) — Der Entwickler beschreibt die Web-Neuauflage mit GPT-6 Astra; das Repository nennt außerdem Claude für Ladehilfen. Originale Spielressourcen behalten ihre eigenen Rechte. [Prüfnotizen](assets/screenshots/hit-and-run-web/SOURCE.md).
+  - Ressourcen: [Quellcode und Einrichtung](https://github.com/Vheissu/hit-and-run-web)
+  - Vorschau: ![Homer in Springfield mit dem ersten Missionsziel und sichtbarer Minikarte.](assets/screenshots/hit-and-run-web/gameplay.jpg)
+
+- **[Where the Wind Wanders](https://app.usecrayon.ai/play/a9a3c165-74b3-4ff6-9588-ad97f829ddb5)** — Wandere durch ein sonniges 2.5D-Tal, folge Pfaden und sammle drei Windbriefe in einem ruhigen Erkundungsabenteuer.
+  - Entwickler: [Tushar](https://x.com/TusharXo)
+  - Plattform: Browser, auf Crayon gehostet; öffentliche Spielseite und eingebetteter Player wurden geprüft.
+  - GPT-6 Astra: [X](https://x.com/TusharXo/status/2096037482739683574) — Tushar beschreibt von Astra erzeugte Wege und Ressourcen; ein Folgebeitrag kündigt die spielbare Fassung mit Astra, Three.js und Crayon an. [Prüfnotizen](assets/screenshots/crayon-adventure/SOURCE.md).
+  - Ressourcen: [Veröffentlichungsbeitrag des Entwicklers](https://x.com/TusharXo/status/2096741535891251261)
+  - Vorschau: ![Figur in einem blumenreichen Tal mit sichtbarem Windbrief-Ziel.](assets/screenshots/crayon-adventure/gameplay.jpg)
+
+- **[ALIBI — The Last Light](https://alibi-blackthorn-manor.vercel.app/)** — Ermittle in Blackthorn Manor in einem Point-and-Click-Mordfall, untersuche Schauplätze und folge Hinweisen zum Täter.
+  - Entwickler: [Christos Antonopoulos](https://x.com/Christos_antono)
+  - Plattform: Browser; interaktiver Herrenhaus-Eingang ohne Anmeldung geöffnet. Später generierte Szenen wurden nicht vollständig getestet.
+  - GPT-6 Astra: [X](https://x.com/Christos_antono/status/2096435122669297892) — Der Entwickler nennt sowohl GPT Astra als auch H3 Max für dieses generative Detektivspiel. [Prüfnotizen](assets/screenshots/alibi-blackthorn-manor/SOURCE.md).
+  - Vorschau: ![Herrenhaus-Eingang mit anklickbarer Tür und einleitendem Ermittlungstext.](assets/screenshots/alibi-blackthorn-manor/gameplay.jpg)
+
+- **[Skyward: The Gathering](https://edge-city-skyward-quests.vercel.app/)** — Erkunde schwebende Inseln, springe und gleite zwischen Gemeinschaften und erledige Aufgaben für ihre Bewohner.
+  - Entwickler: [timour kosters](https://x.com/timourxyz)
+  - Plattform: Desktop-Browser, Tastatur und Maus; Seite und Steuerung der Quest-Version wurden geprüft.
+  - GPT-6 Astra: [X](https://x.com/timourxyz/status/2096379521926840339) — Der Entwickler sagt, Astra habe ein spielbares 3D-Spiel mit NPCs und Aufgaben erstellt, inspiriert von Orten in Edge City. [Prüfnotizen](assets/screenshots/skyward-gathering/SOURCE.md).
+  - Vorschau: ![Skywards schwebende Inseln mit Erkundungs- und Tagebuchsteuerung.](assets/screenshots/skyward-gathering/gameplay.jpg)
+
+- **[Anna & Leo · The Starstone Adventure](https://anna-leo-starstone.vercel.app/)** — Wechsle zwischen Annas Musikmagie und Leos Superkräften, um Melodieblumen zu erwecken und Wonder Garden zu erkunden.
+  - Entwickler: [Dharma Utomo](https://x.com/dharmautomo)
+  - Plattform: Browser; erste Aufgabe ohne Anmeldung gestartet. WASD zur Bewegung, Leertaste zum Springen, E für Kräfte und Tab zum Heldenwechsel.
+  - GPT-6 Astra: [X](https://x.com/dharmautomo/status/2096573649235091967) — Der Entwickler sagt, GPT-6 Astra habe beim Bau des 3D-Abenteuers geholfen, und teilt ein Video seiner Kinder beim Testspielen. [Prüfnotizen](assets/screenshots/anna-leo-starstone/SOURCE.md).
+  - Vorschau: ![3D-Abenteuerwelt von Anna und Leo mit Aufgabenanzeige.](assets/screenshots/anna-leo-starstone/gameplay.jpg)
+
+- **[The Legend of Deller](https://rain-court-js.umodeler-inc-4323.chatgpt.site/)** — Erkunde Rainmist Haven und ziehe mit Schwertkombos, Elementarfähigkeiten und Ausweichbewegungen in Richtung Dungeons.
+  - Entwickler: [UModeler X PicoBerry](https://x.com/UModeler)
+  - Plattform: Desktop-Browser; Tastatur und Maus, ohne Anmeldung. Warte, bis die anfänglichen 3D-Ressourcen geladen sind.
+  - GPT-6 Astra: [Angaben des Entwicklers](https://x.com/UModeler/status/2097792348407099553) — Der Entwickler sagt, PicoBerry habe die Ressourcen erzeugt und GPT-6 Astra das umgebende Three.js-Action-RPG gebaut. [Prüfnotizen](assets/screenshots/the-legend-of-deller/SOURCE.md).
+  - Ressourcen: [Veröffentlichungslink des Entwicklers](https://x.com/UModeler/status/2097792351129178451)
+  - Vorschau: ![Deller weicht neben Brunnen und Marktständen in Rainmist Haven aus; Leben, Mana und Fähigkeiten sind sichtbar.](assets/screenshots/the-legend-of-deller/gameplay.jpg)
+
+- **[Dungeon of Astra](https://wavedash.com/games/dungeon-of-astra)** — Rekrutiere eine Gruppe, steige in einen Dungeon mit hundert Ebenen hinab und kombiniere Schwertangriffe, Feuerbälle und Begleiterrollen in einem Lauf mit dauerhaftem Tod.
+  - Entwickler: [tonysuri / @tonysurix](https://x.com/tonysurix)
+  - Plattform: Desktop-Browser auf Wavedash; Grundspiel ohne Anmeldung. Optionale Konten und kostenpflichtige vorzeitige Charakterfreischaltungen sind verfügbar.
+  - GPT-6 Astra: [Angaben des Entwicklers](https://x.com/tonysurix/status/2097873333551616355) — Der Entwickler erklärt ausdrücklich, dieser gruppenbasierte Dungeon-Crawler sei mit GPT-6 Astra entstanden. [Prüfnotizen](assets/screenshots/dungeon-of-astra/SOURCE.md).
+  - Vorschau: ![Held und angeheuerter Ritter mit Feuerball auf der ersten Dungeon-Ebene, Gruppenleben und Minikarte.](assets/screenshots/dungeon-of-astra/gameplay.jpg)
+
+- **[Sunlandia — The Forgotten Shore](https://sunlandia.smallweblab.com/)** — Erkunde nach einem Schiffbruch eine Insel, untersuche Hinweise aus der Ich-Perspektive und löse Umgebungsrätsel auf dem Weg zum Leuchtturm.
+  - Entwickler: [Ramon Linares / Small Web Lab](https://github.com/RamonLinares)
+  - Plattform: Desktop-Browser; auf die Insel warten, dann Begin expedition wählen. Kostenlos, ohne Konto oder Installation.
+  - GPT-6 Astra: [Entwicklungsbericht](https://smallweblab.com/posts/sunlandia/) — Der Entwickler begann mit GPT-5.6 Sol, erhielt Hilfe von Fable und stellte das Spiel mit GPT-6 Astra fertig. [Prüfnotizen](assets/screenshots/sunlandia/SOURCE.md).
+  - Vorschau: ![Sunlandias Küste aus der Ich-Perspektive mit Wrack, zerbrochenem Steg und dem Ziel, Hilfe zu suchen.](assets/screenshots/sunlandia/gameplay.jpg)
+
+- **[NÁCAR](https://nacar-microcosmo.preda2005.chatgpt.site/)** — Lass einen mikroskopischen Organismus in einem gefluteten Schneckenhaus wachsen, sammle Nährstoffe und entwickle beim Erkunden neue Körperteile.
+  - Entwickler: [Marcio Lima / @Preda2005](https://x.com/Preda2005)
+  - Plattform: Browser; kostenlose Beta ohne Anmeldung, mit fünf Oberflächensprachen einschließlich Chinesisch.
+  - GPT-6 Astra: [Thread des Entwicklers](https://x.com/Preda2005/status/2097954217180921928) — Marcio sagt, er habe GPT-6 Astra diese Idee zur Organismenentwicklung beschrieben und daraus die verlinkte Beta entwickelt. [Prüfnotizen](assets/screenshots/nacar/SOURCE.md).
+  - Vorschau: ![Kleine Zelle zwischen bunten Nährstoffen mit Biomasse, Evolution, Inventar und Anzeigen zum erkundeten Wasser.](assets/screenshots/nacar/gameplay.jpg)
 
 <a id="platformers-racing"></a>
 
@@ -341,6 +511,31 @@ Parkour, Plattformherausforderungen, Rennen und Spiele rund um Bewegung und Wege
   - GPT-6 Astra: [Issue #51](https://github.com/MartinDelophy/awesome-gpt-6-astra/issues/51) — Laut Entwickler: Erstversion mit Qwen3.8 Max, zweite Version mit Astra vollständig neu aufgebaut.
   - Vorschau: ![疾风赛道 / Kart Racing（跑跑卡丁车）](https://github.com/user-attachments/assets/015e0ca1-7032-4d0e-9391-ad3f40d84227)
 
+- **[TIDAL RUSH — Paradise GP](https://tidal-rush-paradise-gp.skirano.chatgpt.site/)** — Drifte auf einer tropischen Kartbahn, nutze Gegenstände und fahre drei Runden gegen sieben Rivalen.
+  - Entwickler: [Pietro Schirano](https://x.com/skirano)
+  - Plattform: Browser; Drei-Runden-Rennen ohne Anmeldung gestartet. Tastatur für Fahren, Driften und Gegenstände sowie Touch-Schaltflächen auf dem Bildschirm.
+  - GPT-6 Astra: [Modellzuordnung](https://openai.com/index/gpt-6-astra/) — OpenAIs Astra-Startseite verlinkt dieses interaktive Kartspiel und nennt Pietro Schirano. Der Entdeckungsbeitrag auf X stammt aus der Community, nicht vom Entwickler selbst. [Prüfnotizen](assets/screenshots/tidal-rush/SOURCE.md).
+  - Ressourcen: [Fund auf X](https://x.com/alexgetmancom/status/2095598460921614825)
+  - Vorschau: ![Tropische Kartstrecke von Tidal Rush mit Rennplatzierung und Driftsteuerung.](assets/screenshots/tidal-rush/gameplay.jpg)
+
+- **[LUNA — Crimson Requiem / 紅月のレクイエム](https://luna-crimson-requiem.ponsuke.chatgpt.site/)** — Springe durch eine gotische Pixel-Art-Stufe, schlage oder zertrample Gegner oder beschwöre einen Angriff in einem kurzen Seitenscroll-Abenteuer.
+  - Entwickler: [音羽ぽんすけ](https://x.com/ponsuke_otowa)
+  - Plattform: Browser, japanische Oberfläche; Tastatur und vom Entwickler angegebene Smartphone-Unterstützung. Ein Level verfügbar.
+  - GPT-6 Astra: [X](https://x.com/ponsuke_otowa/status/2096531744933425299) — Der Entwickler nennt rund 25 Minuten Entwicklung mit Astra und eine Korrektur der Laufanimation; die Musik wird separat Suno zugeschrieben. [Prüfnotizen](assets/screenshots/luna-crimson-requiem/SOURCE.md).
+  - Vorschau: ![LUNA im Kampf auf einer gotischen Straße unter rotem Mond, mit Lebens- und Beschwörungsanzeige.](assets/screenshots/luna-crimson-requiem/gameplay.jpg)
+
+- **[Strange Orbit](https://app.usecrayon.ai/play/47df78e2-1410-45d1-833c-196e1161c0b8)** — Lass Astronauten auf Fahrrädern um Planetenringe rasen, sammle Sternenstaub, nutze Windschatten und beschleunige im Orbital Cup.
+  - Entwickler: [Crayon](https://x.com/usecrayon)
+  - Plattform: Browser auf Crayon; Tastatur und dokumentierte Touch-Steuerung. Die öffentliche Seite bietet Rennen, Zeitfahren und endloses Umherfahren.
+  - GPT-6 Astra: [X](https://x.com/usecrayon/status/2097468975995302167) — Crayon nennt GPT-6 Astra, Crayon Pro und Three.js für das Weltraum-Fahrradspiel. [Prüfnotizen](assets/screenshots/crayon-space-bike/SOURCE.md).
+  - Vorschau: ![Radfahrende Astronauten auf einem Planetenring mit Runden-, Platzierungs- und Sternenstaubanzeige.](assets/screenshots/crayon-space-bike/gameplay.jpg)
+
+- **[One More Vine — Into the Wild](https://onemorevine.bennash.dev/)** — Renne, springe und schwinge durch vier Dschungellevel, sammle Schätze und weiche Krokodilen aus, um deine Zeit zu verbessern.
+  - Entwickler: [Ben Nash](https://x.com/bennash)
+  - Plattform: Browser, Tastatur und Bildschirmsteuerung; erster Level und Anweisungen ohne Anmeldung geladen.
+  - GPT-6 Astra: [X](https://x.com/bennash/status/2096282758930645170) — Der Entwickler bezeichnet es ausdrücklich als vierstufiges, von Pitfall inspiriertes Spiel mit GPT-6 Astra. [Prüfnotizen](assets/screenshots/one-more-vine/SOURCE.md).
+  - Vorschau: ![Dschungel-Plattformlevel mit Lianen, Schätzen, Gruben und Krokodilen.](assets/screenshots/one-more-vine/gameplay.jpg)
+
 - **[混合马里奥Ⅱ · 忍者龙剑传 × 坦克大战 / Mario Mix II](https://aha-xiaoq.github.io/games/mario-mix-2/play.html)** — Erkunde Marios unterirdische Welt 1-2 mit Ryu Hayabusa aus Ninja Gaiden und dem Panzer aus Battle City: Springen, Wandklettern und Kämpfen in Seitenansicht mit Ryu, Kämpfe aus der Vogelperspektive mit dem Panzer oder eine Ninja-Panzer-Staffel zur Rettung der Prinzessin.
   - Ersteller: [在下_小Q（Aha-xiaoQ）](https://github.com/Aha-xiaoQ)
   - Plattform: Desktop-Browser, chinesische Oberfläche, Tastatur empfohlen; kostenlos, ohne Anmeldung oder Installation.
@@ -349,6 +544,37 @@ Parkour, Plattformherausforderungen, Rennen und Spiele rund um Bewegung und Wege
   - Rechte: Inoffizielles Fanspiel; die Rechte an klassischen Figuren, Bildern und Musik verbleiben bei den jeweiligen Rechteinhabern. Materialnachweise stehen auf der ursprünglichen Spielseite.
   - Vorschau: ![Mario Mix II — vom Ersteller bereitgestelltes Videotitelbild, keine Spielaufnahme.](https://aha-xiaoq.github.io/games/mario-mix-2/cover.jpg)
   - Screenshot: ![Der Panzer in Mario Mix II feuert am Eingang zu Welt 1-2; laufende Version 1.0, aufgenommen am 2026-09-09.](assets/screenshots/mario-mix-2/gameplay.jpg)
+
+- **[Bengaluru ORR Rush](https://orr-rush-bengaluru.ravitheja.chatgpt.site/)** — Rase durch Bengalurus Verkehr, weiche Schlaglöchern und Liefermotorrädern aus und schaffe Platz mit Boost oder seitlichem Ausschwenken.
+  - Entwickler: [Ravi Theja](https://x.com/ravithejads)
+  - Plattform: Desktop-Browser; Tastatursteuerung mit optionalem automatischem Gas, ohne Anmeldung.
+  - GPT-6 Astra: [Angaben des Entwicklers](https://x.com/ravithejads/status/2097181044625887392) — Der Entwickler schreibt das Straßenrennspiel in Bengaluru GPT-6 Astra zu. [Prüfnotizen](assets/screenshots/bengaluru-orr-rush/SOURCE.md).
+  - Vorschau: ![Blaues Spielerauto im Verkehr von Bengaluru mit Platzierung, Geschwindigkeit, Uhr und Steuerungshinweisen.](assets/screenshots/bengaluru-orr-rush/gameplay.jpg)
+
+- **[SKICROSS — Alpine Downhill](https://iamsonic.net/2026/mini-games/skicross.html)** — Fahre gegen drei Skifahrer bergab, passiere Tore und Hindernisse und bleibe der Lawine voraus.
+  - Entwickler: [Sonic的奇思妙想](https://x.com/sonic0828)
+  - Plattform: Desktop-Browser; A/D zum Lenken, Leertaste zum Springen, Shift für Boost; ohne Anmeldung oder Download.
+  - GPT-6 Astra: [Angaben des Entwicklers](https://x.com/sonic0828/status/2097601232877781344) — Der Entwickler nennt GPT-6 Astra für die Minispielsammlung und verlinkt dieses Skispiel in einer eigenen Antwort. [Prüfnotizen](assets/screenshots/skicross/SOURCE.md).
+  - Ressourcen: [Veröffentlichungslink des Entwicklers](https://x.com/sonic0828/status/2097601732297814300)
+  - Vorschau: ![Vier Skifahrer auf einer Schneepiste mit Torbonus, Rangfolge, Geschwindigkeit und Lawinenabstand.](assets/screenshots/skicross/gameplay.jpg)
+
+- **[Itsy Bitsy Spider · One More Climb](https://game-bench.piccini.app/games/gpt-6-astra/)** — Klettere an einer moosigen Wand, fange Fliegen für neuen Halt und verstecke dich in Schutzlöchern, bevor der Regen die Spinne wegspült.
+  - Entwickler: [Luiz Piccini](https://piccini.app/)
+  - Plattform: Browser; kostenlos, ohne Anmeldung. WASD oder Bildschirm-Joystick.
+  - GPT-6 Astra: [Game Bench des Entwicklers](https://game-bench.piccini.app/) — Game Bench kennzeichnet dieses veröffentlichte Spiel als GPT-6 Astra canary, high, vom 2026-09-05, erstellt aus der gemeinsamen Spielvorgabe. [Prüfnotizen](assets/screenshots/itsy-bitsy-spider/SOURCE.md).
+  - Vorschau: ![Spinne in zwei Metern Höhe an einer moosigen Ziegelwand mit Halt, Fliegen, Unterschlupf und Joystick.](assets/screenshots/itsy-bitsy-spider/gameplay.jpg)
+
+- **[Desi Mayhem](https://desimayhem.com/)** — Fahre Motorrad durch indischen Stadtverkehr, schlängle dich an Bussen und Autorikschas vorbei und setze Tritte, Schläge und Boosts ein.
+  - Entwickler: [Kishore](https://x.com/GetKishore)
+  - Plattform: Desktop-Browser; kostenlos, ohne Konto. Vor der ersten Fahrt den erzeugten Fahrernamen bestätigen oder bearbeiten.
+  - GPT-6 Astra: [Entwicklungsthread](https://x.com/GetKishore/status/2097906401159102811) — Kishore beschreibt die Weiterentwicklung des Astra-3D-Spiels mit Straßenreferenzen und wiederholten Tests von Verkehr, Unfällen und Fahrerkämpfen. [Prüfnotizen](assets/screenshots/desi-mayhem/SOURCE.md).
+  - Vorschau: ![Motorradrennen in Chennai mit Spielerfahrer, Verkehr, Minikarte, Platzierung und Rennuhr.](assets/screenshots/desi-mayhem/gameplay.jpg)
+
+- **[Cosmic Tides](https://app.usecrayon.ai/play/362ae1e7-29bd-4fbc-9103-00649265d942)** — Steuere ein Fahrzeug über einen galaktischen Ozean, folge leuchtenden Toren und wähle ein Zwei-Runden-Rennen oder endloses Dahingleiten.
+  - Entwickler: [Aniket J](https://x.com/aniketjart)
+  - Plattform: Browser; auf 3D-Ressourcen warten, dann Ride the current wählen. Kostenlos, ohne Anmeldung.
+  - GPT-6 Astra: [X](https://x.com/aniketjart/status/2098207146647433534) — Aniket nennt GPT-6 Astra, Blender MCP und Crayon und beschreibt das Spiel als Experiment mit weiteren geplanten Gameplay-Iterationen. [Prüfnotizen](assets/screenshots/cosmic-tides/SOURCE.md).
+  - Vorschau: ![Laufendes Cosmic-Tides-Rennen vor einem leuchtenden Tor über einem galaktischen Meer, mit Runden und Geschwindigkeit.](assets/screenshots/cosmic-tides/gameplay.jpg)
 
 <a id="experimental-multiplayer"></a>
 
@@ -394,6 +620,12 @@ Ungewöhnliche Spielmechaniken, Online-Wettkämpfe und kooperative Erlebnisse.
   - Plattform: Browser, kostenlos, ohne Anmeldung. Laut Entwickler kann VPN/Proxy nötig sein. Solostart geprüft; Mehrspieler nicht getestet.
   - GPT-6 Astra: [Issue #52](https://github.com/MartinDelophy/awesome-gpt-6-astra/issues/52) — Laut Entwickler: Erstversion mit GPT-6 Astra Pro, spätere Verbesserungen mit GPT-6 Astra in Codex.
   - Vorschau: ![泡泡坦克大作战联机版 / Toon Tank Arena](https://github.com/user-attachments/assets/713d44f3-a77c-452c-ba6d-1231882dc670)
+
+- **[Above the Rooftops](https://app.usecrayon.ai/play/d09bb865-2259-42e2-86cc-fb609a9d6f28)** — Bemale einen Drachen und fliege über Stadtdächer, indem du die Leinenspannung im freien Flug oder in einer Himmelslicht-Aufgabe mit Zeitlimit ausbalancierst.
+  - Entwickler: [Tushar / @TusharXo](https://x.com/TusharXo)
+  - Plattform: Browser; Figur wählen, Dach betreten und Fly auswählen. Kostenlos, ohne Anmeldung.
+  - GPT-6 Astra: [X](https://x.com/TusharXo/status/2098156783181467801) — Tushar nennt ausdrücklich GPT-6 Astra und Crayon für dieses Three.js-Drachenspiel sowie Images 2.5 für die Grafik. [Prüfnotizen](assets/screenshots/above-the-rooftops/SOURCE.md).
+  - Vorschau: ![Drachenflug-Aufgabe über der Stadt mit Höhe, Leinenspannung, Himmelslicht-Fortschritt und Steuerung.](assets/screenshots/above-the-rooftops/gameplay.jpg)
 
 ## Was ein Eintrag enthält
 

--- a/README.es.md
+++ b/README.es.md
@@ -4,7 +4,7 @@
 
 # Awesome GPT-6 Astra
 
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](CONTRIBUTING.md) [![LINUX DO](https://img.shields.io/badge/LINUX%20DO-Community-f0b73f?style=flat-square)](https://linux.do/) [![Cases: 49](https://img.shields.io/badge/Cases-49-58a6ff?style=flat-square)](https://astragames.aigccreative.com/)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](CONTRIBUTING.md) [![LINUX DO](https://img.shields.io/badge/LINUX%20DO-Community-f0b73f?style=flat-square)](https://linux.do/) [![Cases: 86](https://img.shields.io/badge/Cases-86-58a6ff?style=flat-square)](https://astragames.aigccreative.com/)
 
 **Una colección de juegos interesantes creados con GPT-6 Astra.**
 
@@ -22,7 +22,7 @@ Esta página es una traducción del [README en inglés](README.md). Consulta el 
 
 ## Empieza aquí
 
-Explora **49 juegos y proyectos interactivos**: estrategia territorial de los Tres Reinos, rompecabezas de madera entrelazada y de piezas deslizantes, fusión de frutas deformables, vuelo con un solo botón, combates en alfombra mágica, defensa de una isla mediante una red eléctrica, supervivencia en la naturaleza, pesca submarina, gestión de un restaurante de sushi y agricultura en una isla, carreras de karts en Bay Circuit, ciclismo costero con un pelícano, juguetes de mesa adaptados a 3D y Orbital Garden. Haz clic en un título para jugar directamente en el navegador.
+Explora **86 juegos y proyectos interactivos**: estrategia territorial de los Tres Reinos, rompecabezas de madera entrelazada y de piezas deslizantes, fusión de frutas deformables, 2048 de construcción de ciudades con generación procedural, vuelo con un solo botón, combates en alfombra mágica, un shooter de lluvia de balas con cinco niveles, defensa de una isla mediante una red eléctrica, supervivencia en la naturaleza, pesca submarina, gestión de un restaurante de sushi y agricultura en una isla, carreras de karts en Bay Circuit, ciclismo costero con un pelícano, juguetes de mesa adaptados a 3D, decoración de hogares en 3D y Orbital Garden. Haz clic en un título para jugar directamente en el navegador.
 
 Catálogo actualizado: **2026-09-12**. El uso del modelo se documenta según las declaraciones de los creadores o remitentes; los datos sin confirmar se señalan en cada entrada. Esta fecha corresponde al mantenimiento del catálogo, no a una nueva prueba de todos los juegos.
 
@@ -110,6 +110,70 @@ Juegos de disparos, lucha, supervivencia, ritmo y cualquier propuesta que invite
   - GPT-6 Astra: [X](https://x.com/jumperz/status/2096600055301984738) — El autor indica que utilizó Astra para desarrollar este proyecto. [Notas de verificación (inglés)](assets/screenshots/cinderfall/SOURCE.md).
   - Vista previa: ![Cinderfall · Fire, Shadow & Steel](assets/screenshots/cinderfall/gameplay.jpg)
 
+- **[Oz Breakdance](https://satriodewantono.com/breakdance/)** — Arrastra las extremidades de un bailarín con física de muñeco hasta los objetivos indicados para puntuar y prolongar una ronda cronometrada de breaking.
+  - Creador: [Satrio](https://x.com/satrio_d)
+  - Plataforma: Navegador de escritorio, ratón; se inició una ronda cronometrada sin iniciar sesión.
+  - GPT-6 Astra: [X](https://x.com/satrio_d/status/2096022866097758500) — El creador afirma que Astra mejoró su juego de breakdance existente y su presentación. [Notas de verificación](assets/screenshots/breakdance/SOURCE.md).
+  - Vista previa: ![Un bailarín con física de muñeco intenta alcanzar un objetivo con el pie en la pista cronometrada.](assets/screenshots/breakdance/gameplay.jpg)
+
+- **[Astral War](https://astralwar.io/)** — Un FPS de navegador ambientado en la Segunda Guerra Mundial, con apariencias de soldados y zombis, equipamiento de armas, entrenamiento con bots y opciones de sala.
+  - Creador: [Rishi](https://x.com/0xRishi)
+  - Plataforma: Navegador de escritorio, teclado y ratón; se inició el entrenamiento con bots sin iniciar sesión. No se probaron el multijugador ni los mandos.
+  - GPT-6 Astra: [X](https://x.com/0xRishi/status/2096079660605997264) — Rishi afirma haber creado Astral War con Astra, Three.js, Meshy y ElevenLabs. El sitio actual también acredita a Vesper; véase la nota de atribución. [Notas de verificación](assets/screenshots/astral-war/SOURCE.md).
+  - Vista previa: ![Vista de combate de Astral War con el arma y los controles del campo de batalla.](assets/screenshots/astral-war/gameplay.jpg)
+
+- **[FLOP CLUB](https://bubucn.com/ai-model-evals/flop-club/game/index.html)** — Salta desde tres alturas, realiza volteretas y giros, y apunta a un aro flotante para mejorar la puntuación de entrada al agua.
+  - Creador: [BubuAi](https://x.com/BubuStd)
+  - Plataforma: Navegador; el juego independiente arranca sin iniciar sesión ni descargar nada. Se inició un salto en la comprobación del 2026-09-09; controles de teclado y táctiles documentados.
+  - GPT-6 Astra: [X](https://x.com/BubuStd/status/2096402783805354091) — El creador afirma que lo construyó con Astra Pro y Three.js a partir de un solo prompt. [Notas de verificación](assets/screenshots/flop-club/SOURCE.md).
+  - Recursos: [Presentación del proyecto](https://bubucn.com/zh/ai-model-evals/flop-club)
+  - Vista previa: ![Un saltador en la plataforma elevada, sobre el aro objetivo y los controles de entrada al agua.](assets/screenshots/flop-club/gameplay.jpg)
+
+- **[Vector Dive — Beyond the Signal](https://vector-dive.openai.chatgpt.site/)** — Pilota por circuitos de neón con estructura alámbrica que aceleran en cada vuelta; usa el impulso y el cambio de fase en el momento justo para sobrevivir.
+  - Creador: [Thomas Ricouard](https://x.com/Dimillian)
+  - Plataforma: Navegador de escritorio; se inició un vuelo con puntuación sin iniciar sesión. WASD para volar, Espacio para impulsar y Shift para cambiar de fase.
+  - GPT-6 Astra: [X](https://x.com/Dimillian/status/2097188900888322323) — El creador afirma que Astra hizo el juego y la música a partir de una propuesta visual neón/synthwave y arte conceptual. [Notas de verificación](assets/screenshots/vector-dive/SOURCE.md).
+  - Vista previa: ![Circuito de vuelo de neón de Vector Dive con la nave y los indicadores de juego.](assets/screenshots/vector-dive/gameplay.jpg)
+
+- **[Harbor Skirmish](https://gpt6astra-game.vercel.app/)** — Defiende un pueblo costero de oleadas de conejos revoltosos con tres armas, rutas por los tejados, desplazamientos rápidos y un gancho.
+  - Creador: [OpenDesign](https://x.com/OpenDesignHQ)
+  - Plataforma: Navegador de escritorio; teclado y ratón, sin iniciar sesión ni descargar nada.
+  - GPT-6 Astra: [Declaración del creador](https://x.com/OpenDesignHQ/status/2097635757917983223) — OpenDesign identifica este juego de Three.js como la versión hecha con GPT-6 Astra en su comparación de dos modelos. [Notas de verificación](assets/screenshots/harbor-skirmish/SOURCE.md).
+  - Vista previa: ![Vista de un rifle en primera persona en Seabreeze, con conejos acercándose, contador de oleadas y controles de armas.](assets/screenshots/harbor-skirmish/gameplay.jpg)
+
+- **[UNDERGROUND — Underground Boxing](https://iamsonic.net/2026/mini-games/underground-boxing.html)** — Boxea durante tres asaltos cronometrados en un ring subterráneo 3D, equilibrando golpes, bloqueos, esquivas y resistencia.
+  - Creador: [Sonic的奇思妙想](https://x.com/sonic0828)
+  - Plataforma: Navegador de escritorio; WASD para moverse, J/K para golpear, L para bloquear y Espacio para esquivar; sin iniciar sesión ni descargar nada.
+  - GPT-6 Astra: [Declaración del creador](https://x.com/sonic0828/status/2097601232877781344) — El hilo de presentación del creador atribuye estos minijuegos a GPT-6 Astra; su respuesta sobre boxeo enlaza esta versión. [Notas de verificación](assets/screenshots/underground-boxing/SOURCE.md).
+  - Recursos: [Enlace de lanzamiento del creador](https://x.com/sonic0828/status/2097601584410796401)
+  - Vista previa: ![Dos boxeadores intercambian golpes en un ring subterráneo iluminado, con cronómetro, salud y resistencia.](assets/screenshots/underground-boxing/gameplay.jpg)
+
+- **[Urban Champion 3D](https://iamsonic.net/2026/mini-games/urban-champion.html)** — Alterna golpes altos y bajos en una calle al atardecer, bloquea contraataques y empuja al rival a una alcantarilla mientras evitas macetas que caen.
+  - Creador: [Sonic的奇思妙想](https://x.com/sonic0828)
+  - Plataforma: Navegador de escritorio; A/D para moverse, J/K para golpear, U/I para bloquear y Espacio para esquivar; sin iniciar sesión.
+  - GPT-6 Astra: [Declaración del creador](https://x.com/sonic0828/status/2097601232877781344) — La presentación de GPT-6 Astra del creador incluye una respuesta de lanzamiento específica que enlaza este juego de lucha callejera. [Notas de verificación](assets/screenshots/urban-champion-3d/SOURCE.md).
+  - Recursos: [Enlace de lanzamiento del creador](https://x.com/sonic0828/status/2097601861658587376)
+  - Vista previa: ![Luchadores azul y rojo ante Sunset Mart, con cronómetro del asalto y barras de resistencia.](assets/screenshots/urban-champion-3d/gameplay.jpg)
+
+- **[Zero District — Shells 3D](https://iamsonic.net/2026/mini-games/shells-3d/play.html)** — Sobrevive a un asedio urbano de tres minutos con disparo automático, esquivas mediante movimiento, experiencia para recoger y mejoras a elegir.
+  - Creador: [Sonic的奇思妙想](https://x.com/sonic0828)
+  - Plataforma: Navegador; WASD o arrastrar para moverse, apuntado automático; sin iniciar sesión ni descargar nada.
+  - GPT-6 Astra: [Declaración del creador](https://x.com/sonic0828/status/2097601232877781344) — El creador menciona GPT-6 Astra en el anuncio de la colección y enlaza esta versión de supervivencia 3D en una respuesta propia. [Notas de verificación](assets/screenshots/zero-district-shells-3d/SOURCE.md).
+  - Recursos: [Enlace de lanzamiento del creador](https://x.com/sonic0828/status/2097602391122264310)
+  - Vista previa: ![Un superviviente dispara automáticamente a enemigos en una calle, con 14 bajas y 166 segundos restantes.](assets/screenshots/zero-district-shells-3d/gameplay.jpg)
+
+- **[ASCII DISTRICT](https://ascii-district.vercel.app/)** — Combate oleadas de virus informáticos en una arena en primera persona dibujada con caracteres ASCII, con carrera, salto y deslizamiento.
+  - Creador: [Acker Code](https://x.com/acker_code)
+  - Plataforma: Navegador de escritorio; teclado y ratón, sin iniciar sesión. Haz clic en la arena para capturar el ratón; Esc lo libera.
+  - GPT-6 Astra: [Declaración del creador](https://x.com/acker_code/status/2097542957070975286) — El creador acredita explícitamente a Codex y GPT-6 Astra por este shooter de arte ASCII. [Notas de verificación](assets/screenshots/ascii-district/SOURCE.md).
+  - Vista previa: ![Patio ASCII con virus acercándose e indicadores del rifle con 29 balas tras disparar.](assets/screenshots/ascii-district/gameplay.jpg)
+
+- **[Aura Farming: Unbothered](https://www.aigameshare.com/games/aura-farming-game)** — Mantén en equilibrio a una capibara bailarina sobre un barco dragón, inclínate contra las olas y completa seis movimientos en 40 segundos.
+  - Creador: [nilni / @nil](https://www.aigameshare.com/profile/nil)
+  - Plataforma: Navegador de escritorio; juego gratuito sin iniciar sesión. Pulsa Play; las funciones de cuenta son opcionales.
+  - GPT-6 Astra: [Ficha del creador](https://www.aigameshare.com/games/aura-farming-game) — El creador acredita a GPT-6 Astra y Codex, junto con Blender, Three.js, ImageGen y WebAudio. [Notas de verificación](assets/screenshots/aura-farming/SOURCE.md).
+  - Vista previa: ![Una capibara baila sobre un barco dragón, con controles de inclinación y apoyo e indicadores del reto de seis movimientos.](assets/screenshots/aura-farming/gameplay.jpg)
+
 <a id="puzzles"></a>
 
 ### Puzles e ingenio
@@ -135,6 +199,25 @@ Acertijos de lógica, desafíos de física, juegos de palabras y pequeños mecan
   - Participación del modelo: [Registro de creación](works/sunjing-puzzles/CREATION.md) — Trabajo iterativo en Codex sobre diseño del juego, gráficos 3D procedurales, reglas, solucionador y pruebas; el uso concreto de GPT-6 Astra está pendiente de confirmación del creador (propuesta provisional).
   - Recursos: [Código fuente e instrucciones de ejecución](works/sunjing-puzzles/README.md) · [Requisitos](works/sunjing-puzzles/PROMPTS.md) · Tecnologías: React, Vinext/Vite, Three.js.
   - Vista previa: ![Rompecabezas de madera de seis piezas de Sunjing sobre un banco 3D verde, con piezas numeradas y controles de extracción.](assets/screenshots/sunjing-puzzles/gameplay.jpg)
+
+- **[CityMaker](https://citymaker.0to1app.com)** — Un puzle 2048 sobre una manzana urbana de 4×4: fusiona edificios iguales para ascender once niveles arquitectónicos por ciudad, desde casas tradicionales hasta un skyline reconocible, en doce ciudades con vista giratoria en pasos de 45°.
+  - Creador: [Derek Wang](https://github.com/derek-wangpch)
+  - Plataforma: Navegadores de escritorio y móviles con WebGL; inglés, chino simplificado y tradicional. Gratis, sin login ni clave API; guarda el progreso por ciudad en el navegador actual y permite instalarse en la pantalla de inicio de iOS.
+  - GPT-6 Astra: [Registro de creación](https://github.com/derek-wangpch/OpenCityMaker/blob/master/docs/CREATION.md) — El creador afirma que GPT-6 Astra generó la geometría procedural de los 132 edificios mediante referencias, investigación de múltiples vistas, modelado inicial de siluetas y validación con capturas; no fue una prueba de un solo prompt.
+  - Recursos: [Código e instalación](https://github.com/derek-wangpch/OpenCityMaker) · [Notas de verificación](https://github.com/derek-wangpch/OpenCityMaker/blob/master/QA.md) · Tecnología: React, TypeScript, Vite y Three.js; los 132 modelos de edificios son geometría procedural original.
+  - Vista previa: ![Tablero de Hong Kong de CityMaker con edificios 3D de pocos polígonos en una cuadrícula 4×4, puntuación, selector de ciudades y controles de rotación.](assets/screenshots/citymaker/gameplay.png)
+
+- **[Bonkshot](https://bonkshot.com/)** — Tensa un tirachinas y lanza pequeños Bonkers contra soportes de madera para derribar estructuras y eliminar objetivos.
+  - Creador: [edmund5](https://x.com/edmund5)
+  - Plataforma: Navegador; arrastra para apuntar y suelta para lanzar. Se puede jugar sin iniciar sesión; el acceso con Google es opcional.
+  - GPT-6 Astra: [Declaración del creador](https://x.com/edmund5/status/2097603093819261002) — El creador acredita a GPT-6 Astra y Three.js por el juego, y a Suno por la música de fondo. [Notas de verificación](assets/screenshots/bonkshot/SOURCE.md).
+  - Vista previa: ![Primer puzle de Grasslands tras un lanzamiento: torre de madera parcialmente derrumbada, un objetivo restante y 2.200 puntos.](assets/screenshots/bonkshot/gameplay.jpg)
+
+- **[Greenhouse Escape Room: The Last Seed](https://www.aigameshare.com/games/greenhouse-escape-room)** — Explora un invernadero sellado, repara tuberías de cobre, organiza plantas y luz reflejada, y rescata su última semilla.
+  - Creador: [nilni / @nil](https://www.aigameshare.com/profile/nil)
+  - Plataforma: Navegador; pulsa Play y luego Begin. Gratis, sin iniciar sesión; controles en inglés y chino.
+  - GPT-6 Astra: [Ficha del creador](https://www.aigameshare.com/games/greenhouse-escape-room) — El creador identifica GPT-6 Astra y Codex como herramientas de desarrollo, junto con ImageGen y WebAudio. [Notas de verificación](assets/screenshots/greenhouse-escape-room/SOURCE.md).
+  - Vista previa: ![Sala Waterworks del juego de escape, con un mecanismo de tuberías de nueve casillas, cronómetro e inventario.](assets/screenshots/greenhouse-escape-room/gameplay.jpg)
 
 <a id="strategy-simulation"></a>
 
@@ -227,6 +310,24 @@ Defensa de torres, cartas estratégicas, gestión, construcción y simulación d
   - Recursos: [GitHub](https://github.com/LucasMarquesShiva/the-free-game)
   - Vista previa: ![The Free Game](assets/screenshots/the-free-game/gameplay.jpg)
 
+- **[AGI of Empires — The Compute Wars](https://agiofempires.com/)** — Reúne financiación y GPU, construye centros de datos y ejércitos, y compite con laboratorios de IA por alcanzar la ASI o destruye sus cuarteles.
+  - Creador: [timour kosters](https://x.com/timourxyz)
+  - Plataforma: Navegador de escritorio; estrategia en tiempo real satírica y gratuita. Se verificaron el inicio contra la computadora y la recolección de recursos sin iniciar sesión.
+  - GPT-6 Astra: [X](https://x.com/timourxyz/status/2096662786692776293) — El creador afirma que desarrolló este juego inspirado en Age of Empires con Astra durante dos días. [Notas de verificación](assets/screenshots/agi-of-empires/SOURCE.md).
+  - Vista previa: ![Campo de batalla de AGI of Empires, contadores de recursos y cuartel general.](assets/screenshots/agi-of-empires/gameplay.jpg)
+
+- **[Atlas Go](https://atlas-go.borisxp.chatgpt.site/)** — Juega al go sobre redes de calles y tableros de grafos inusuales, con turnos locales compartiendo dispositivo y opciones de partidas con amigos.
+  - Creador: [Boris Power](https://x.com/BorisMPower)
+  - Plataforma: Navegador; se abrió el tablero local sin iniciar sesión. No se probaron las partidas en línea con amigos.
+  - GPT-6 Astra: [X](https://x.com/BorisMPower/status/2096784808399843582) — El creador describe este go multijugador sobre grafos arbitrarios como una creación de Astra con un solo prompt. [Notas de verificación](assets/screenshots/atlas-go/SOURCE.md).
+  - Vista previa: ![Piedras negras y blancas sobre el tablero de grafo hexagonal de Atlas Go.](assets/screenshots/atlas-go/gameplay.jpg)
+
+- **[Ironwood — The Art of Industry](https://ironwood.sparkles.dev/)** — Recoge materias primas, alimenta máquinas y conecta cintas transportadoras para convertir un claro en una fábrica operativa.
+  - Creador: [Dan](https://x.com/aidaniil)
+  - Plataforma: Navegador de escritorio; el tutorial de invitado abre sin iniciar sesión, pero guardar el progreso requiere una cuenta. El multijugador no se probó de forma independiente.
+  - GPT-6 Astra: [X](https://x.com/aidaniil/status/2096426970930106530) — El creador afirma que él y su hermano lo hicieron con Astra, Blender MCP y Cloudflare Durable Objects, inspirados en Satisfactory y Besiege. [Notas de verificación](assets/screenshots/ironwood/SOURCE.md).
+  - Vista previa: ![Máquinas, cintas transportadoras y tutorial de gestión de recursos de Ironwood.](assets/screenshots/ironwood/gameplay.jpg)
+
 - **[DUST FRONT](https://dust-front.mustafaakin.dev/)** — Un RTS para un jugador con construcción de bases, captura de posiciones y mando de fuerzas terrestres y aéreas.
   - Creador: [Mustafa Akın](https://x.com/mustafaakin)
   - Plataforma: Navegador de escritorio; teclado y ratón, sin inicio de sesión obligatorio.
@@ -239,6 +340,18 @@ Defensa de torres, cartas estratégicas, gestión, construcción y simulación d
   - GPT-6 Astra: [X](https://x.com/HDLhN783wtLkpPR/status/2097321360641122393) — El creador afirma en la publicación enlazada que utilizó «GPT Astra» para crear este juego de estrategia en tiempo real; no especifica la versión exacta del modelo ni el proceso detallado de desarrollo.
   - Referencias: [Propuesta](https://github.com/MartinDelophy/awesome-gpt-6-astra/issues/66) · [Notas de verificación (inglés)](assets/screenshots/frontline-command/SOURCE.md)
   - Vista previa: ![Frontline Command: base, tres tanques seleccionados y colocación de una central eléctrica durante una partida; v0.8, capturada el 2026-09-09.](assets/screenshots/frontline-command/gameplay.jpg)
+
+- **[Coin Pusher Roguelite: Mintfall](https://www.aigameshare.com/games/coin-pusher-roguelite-mintfall)** — Apunta en una máquina empujamonedas 3D, combina monedas especiales y reliquias, y supera seis rondas con lanzamientos limitados y metas de puntuación.
+  - Creador: [nilni / @nil](https://www.aigameshare.com/profile/nil)
+  - Plataforma: Navegador; pulsa Play, gratis y sin iniciar sesión. Guardado con cuenta opcional.
+  - GPT-6 Astra: [Ficha del creador](https://www.aigameshare.com/games/coin-pusher-roguelite-mintfall) — El creador acredita a GPT-6 Astra junto con GPT-5.6 Sol y Codex; la ficha no distingue sus contribuciones. [Notas de verificación](assets/screenshots/mintfall/SOURCE.md).
+  - Vista previa: ![Bandeja 3D de Mintfall en la ronda 1, con 33 puntos, 44 lanzamientos y controles de monedas especiales.](assets/screenshots/mintfall/gameplay.jpg)
+
+- **[Westward — The Oregon Trail](https://biswaz.me/westward/)** — Guía una caravana hacia el oeste, raciona comida, gestiona reparaciones y caza, y toma decisiones a lo largo de la ruta de Oregón.
+  - Creador: [Biswas](https://x.com/bis_waz)
+  - Plataforma: Navegador de escritorio; comienza con el grupo ficticio proporcionado, sin iniciar sesión ni instalar nada.
+  - GPT-6 Astra: [X](https://x.com/bis_waz/status/2098023593468907747) — Biswas afirma que usó GPT-6 Astra para crear esta versión moderna en 3D de The Oregon Trail y enlaza el juego. [Notas de verificación](assets/screenshots/westward/SOURCE.md).
+  - Vista previa: ![Carreta y bueyes camino del río Kansas, con 25 millas recorridas y panel de suministros.](assets/screenshots/westward/gameplay.jpg)
 
 <a id="rpg-adventures"></a>
 
@@ -276,6 +389,63 @@ Juegos de rol, exploración, aventuras narrativas e historias interactivas.
   - Plataforma: Navegador de escritorio; abierto sin registro ni pago. Móvil no probado.
   - GPT-6 Astra: [X](https://x.com/emollick/status/2096047660662722620) — El autor indica que utilizó Astra para desarrollar este proyecto. [Notas de verificación (inglés)](assets/screenshots/zork/SOURCE.md).
   - Vista previa: ![Zork · The Great Underground Empire](assets/screenshots/zork/gameplay.jpg)
+
+- **[The Simpsons: Hit & Run — Browser Recreation](https://vheissu.github.io/hit-and-run-web/)** — Explora Springfield a pie y en coche en una recreación no oficial para navegador con misiones, tráfico y persecuciones policiales.
+  - Creador: [Dwayne](https://x.com/CtrlAltDwayne)
+  - Plataforma: Navegador de escritorio; la primera misión cargó sin iniciar sesión tras una descarga inicial considerable de recursos. No se comprobó la campaña completa.
+  - GPT-6 Astra: [X](https://x.com/CtrlAltDwayne/status/2096872309936287887) — El creador describe la reconstrucción para la web con GPT-6 Astra; el repositorio también acredita ayuda de Claude con la carga. Los recursos del juego original conservan sus derechos. [Notas de verificación](assets/screenshots/hit-and-run-web/SOURCE.md).
+  - Recursos: [Código e instalación](https://github.com/Vheissu/hit-and-run-web)
+  - Vista previa: ![Homer en Springfield, con el objetivo de la primera misión y el minimapa visibles.](assets/screenshots/hit-and-run-web/gameplay.jpg)
+
+- **[Where the Wind Wanders](https://app.usecrayon.ai/play/a9a3c165-74b3-4ff6-9588-ad97f829ddb5)** — Recorre un valle soleado en 2.5D, sigue senderos y reúne tres cartas del viento en una aventura de exploración tranquila.
+  - Creador: [Tushar](https://x.com/TusharXo)
+  - Plataforma: Navegador, alojado en Crayon; se comprobaron la página pública y el reproductor integrado.
+  - GPT-6 Astra: [X](https://x.com/TusharXo/status/2096037482739683574) — Tushar describe cómo Astra generó senderos y recursos; una publicación posterior anuncia la versión jugable con Astra, Three.js y Crayon. [Notas de verificación](assets/screenshots/crayon-adventure/SOURCE.md).
+  - Recursos: [Publicación de lanzamiento del creador](https://x.com/TusharXo/status/2096741535891251261)
+  - Vista previa: ![Un personaje explora un valle lleno de flores, con el objetivo de las cartas del viento visible.](assets/screenshots/crayon-adventure/gameplay.jpg)
+
+- **[ALIBI — The Last Light](https://alibi-blackthorn-manor.vercel.app/)** — Investiga Blackthorn Manor en un misterio de asesinato de apuntar y hacer clic; examina escenas y sigue pistas para identificar al culpable.
+  - Creador: [Christos Antonopoulos](https://x.com/Christos_antono)
+  - Plataforma: Navegador; la entrada interactiva de la mansión abrió sin iniciar sesión. Las escenas generadas posteriores no se probaron por completo.
+  - GPT-6 Astra: [X](https://x.com/Christos_antono/status/2096435122669297892) — El creador acredita tanto a GPT Astra como a H3 Max por este juego detectivesco generativo. [Notas de verificación](assets/screenshots/alibi-blackthorn-manor/SOURCE.md).
+  - Vista previa: ![Entrada de la mansión con una puerta interactiva y el texto inicial de la investigación.](assets/screenshots/alibi-blackthorn-manor/gameplay.jpg)
+
+- **[Skyward: The Gathering](https://edge-city-skyward-quests.vercel.app/)** — Explora islas flotantes, salta y planea entre comunidades, y completa encargos para sus habitantes.
+  - Creador: [timour kosters](https://x.com/timourxyz)
+  - Plataforma: Navegador de escritorio, teclado y ratón; se comprobaron la página y los controles de la edición con misiones.
+  - GPT-6 Astra: [X](https://x.com/timourxyz/status/2096379521926840339) — El creador afirma que Astra construyó un juego 3D jugable con PNJ y misiones inspiradas en lugares de Edge City. [Notas de verificación](assets/screenshots/skyward-gathering/SOURCE.md).
+  - Vista previa: ![Vista de las islas flotantes de Skyward con controles de exploración y diario.](assets/screenshots/skyward-gathering/gameplay.jpg)
+
+- **[Anna & Leo · The Starstone Adventure](https://anna-leo-starstone.vercel.app/)** — Alterna entre la magia musical de Anna y los superpoderes de Leo para despertar flores melódicas y explorar Wonder Garden.
+  - Creador: [Dharma Utomo](https://x.com/dharmautomo)
+  - Plataforma: Navegador; se inició la primera misión sin iniciar sesión. WASD para moverse, Espacio para saltar, E para el poder y Tab para cambiar de héroe.
+  - GPT-6 Astra: [X](https://x.com/dharmautomo/status/2096573649235091967) — El creador afirma que GPT-6 Astra le ayudó a crear la aventura 3D y comparte un vídeo de sus hijos probándola. [Notas de verificación](assets/screenshots/anna-leo-starstone/SOURCE.md).
+  - Vista previa: ![Mundo de aventura 3D de Anna y Leo con la interfaz de misiones.](assets/screenshots/anna-leo-starstone/gameplay.jpg)
+
+- **[The Legend of Deller](https://rain-court-js.umodeler-inc-4323.chatgpt.site/)** — Explora Rainmist Haven y avanza hacia mazmorras con combos de espada, habilidades elementales y movimientos evasivos.
+  - Creador: [UModeler X PicoBerry](https://x.com/UModeler)
+  - Plataforma: Navegador de escritorio; teclado y ratón, sin iniciar sesión. Espera a que terminen de cargar los recursos 3D iniciales.
+  - GPT-6 Astra: [Declaración del creador](https://x.com/UModeler/status/2097792348407099553) — El creador afirma que PicoBerry generó los recursos y GPT-6 Astra construyó el RPG de acción en Three.js que los rodea. [Notas de verificación](assets/screenshots/the-legend-of-deller/SOURCE.md).
+  - Recursos: [Enlace de lanzamiento del creador](https://x.com/UModeler/status/2097792351129178451)
+  - Vista previa: ![Deller esquiva junto a una fuente y puestos de mercado de Rainmist Haven, con salud, maná y habilidades.](assets/screenshots/the-legend-of-deller/gameplay.jpg)
+
+- **[Dungeon of Astra](https://wavedash.com/games/dungeon-of-astra)** — Recluta un grupo, desciende una mazmorra de cien pisos y combina espadas, bolas de fuego y funciones de compañeros en una partida con muerte permanente.
+  - Creador: [tonysuri / @tonysurix](https://x.com/tonysurix)
+  - Plataforma: Navegador de escritorio en Wavedash; el juego base comienza sin iniciar sesión. Hay cuentas opcionales y desbloqueos anticipados de personajes de pago.
+  - GPT-6 Astra: [Declaración del creador](https://x.com/tonysurix/status/2097873333551616355) — El creador afirma explícitamente que este juego de mazmorras por grupos fue creado con GPT-6 Astra. [Notas de verificación](assets/screenshots/dungeon-of-astra/SOURCE.md).
+  - Vista previa: ![El héroe y un caballero contratado lanzan una bola de fuego en el primer piso, con salud del grupo y minimapa.](assets/screenshots/dungeon-of-astra/gameplay.jpg)
+
+- **[Sunlandia — The Forgotten Shore](https://sunlandia.smallweblab.com/)** — Explora una isla tras naufragar, investiga pistas en primera persona y resuelve puzles del entorno camino del faro.
+  - Creador: [Ramon Linares / Small Web Lab](https://github.com/RamonLinares)
+  - Plataforma: Navegador de escritorio; espera a que cargue la isla y pulsa Begin expedition. Gratis, sin cuenta ni instalación.
+  - GPT-6 Astra: [Diario del creador](https://smallweblab.com/posts/sunlandia/) — El creador comenzó con GPT-5.6 Sol, recibió ayuda de Fable y terminó el juego con GPT-6 Astra. [Notas de verificación](assets/screenshots/sunlandia/SOURCE.md).
+  - Vista previa: ![Costa de Sunlandia en primera persona, con el naufragio, el muelle roto y el objetivo de buscar ayuda.](assets/screenshots/sunlandia/gameplay.jpg)
+
+- **[NÁCAR](https://nacar-microcosmo.preda2005.chatgpt.site/)** — Haz crecer un organismo microscópico dentro de una concha de caracol inundada, reúne nutrientes y desarrolla nuevas partes del cuerpo al explorar.
+  - Creador: [Marcio Lima / @Preda2005](https://x.com/Preda2005)
+  - Plataforma: Navegador; beta gratuita sin iniciar sesión, con cinco idiomas de interfaz, incluido el chino.
+  - GPT-6 Astra: [Hilo del creador](https://x.com/Preda2005/status/2097954217180921928) — Marcio afirma que describió la idea de evolución del organismo a GPT-6 Astra y la desarrolló hasta la beta enlazada. [Notas de verificación](assets/screenshots/nacar/SOURCE.md).
+  - Vista previa: ![Una célula entre nutrientes de colores, con biomasa, evolución, inventario y controles de agua explorada.](assets/screenshots/nacar/gameplay.jpg)
 
 <a id="platformers-racing"></a>
 
@@ -341,6 +511,31 @@ Parkour, desafíos de plataformas, carreras y juegos centrados en el movimiento 
   - GPT-6 Astra: [Issue #51](https://github.com/MartinDelophy/awesome-gpt-6-astra/issues/51) — Según el creador: Primera versión con Qwen3.8 Max; segunda reconstruida por completo con Astra.
   - Vista previa: ![疾风赛道 / Kart Racing（跑跑卡丁车）](https://github.com/user-attachments/assets/015e0ca1-7032-4d0e-9391-ad3f40d84227)
 
+- **[TIDAL RUSH — Paradise GP](https://tidal-rush-paradise-gp.skirano.chatgpt.site/)** — Derrapa en un circuito tropical de karts, usa objetos y compite contra siete rivales durante tres vueltas.
+  - Creador: [Pietro Schirano](https://x.com/skirano)
+  - Plataforma: Navegador; se inició la carrera de tres vueltas sin iniciar sesión. Teclado para conducir, derrapar y usar objetos, además de botones táctiles en pantalla.
+  - GPT-6 Astra: [Atribución del modelo](https://openai.com/index/gpt-6-astra/) — La página de lanzamiento de Astra de OpenAI enlaza este kart interactivo y acredita a Pietro Schirano. La publicación de descubrimiento en X es de la comunidad, no del creador. [Notas de verificación](assets/screenshots/tidal-rush/SOURCE.md).
+  - Recursos: [Publicación de descubrimiento en X](https://x.com/alexgetmancom/status/2095598460921614825)
+  - Vista previa: ![Circuito tropical de Tidal Rush, con posición de carrera y controles de derrape.](assets/screenshots/tidal-rush/gameplay.jpg)
+
+- **[LUNA — Crimson Requiem / 紅月のレクイエム](https://luna-crimson-requiem.ponsuke.chatgpt.site/)** — Salta por un escenario gótico de pixel art, ataca con tajos, pisa enemigos o invoca un ataque en una breve aventura lateral.
+  - Creador: [音羽ぽんすけ](https://x.com/ponsuke_otowa)
+  - Plataforma: Navegador, interfaz japonesa; teclado y soporte para smartphones indicado por el creador. Hay un escenario disponible.
+  - GPT-6 Astra: [X](https://x.com/ponsuke_otowa/status/2096531744933425299) — El creador informa de unos 25 minutos de desarrollo con Astra y una corrección de la animación al caminar; la música se acredita por separado a Suno. [Notas de verificación](assets/screenshots/luna-crimson-requiem/SOURCE.md).
+  - Vista previa: ![LUNA combate en una calle gótica bajo una luna roja, con salud y medidor de invocación.](assets/screenshots/luna-crimson-requiem/gameplay.jpg)
+
+- **[Strange Orbit](https://app.usecrayon.ai/play/47df78e2-1410-45d1-833c-196e1161c0b8)** — Compite con ciclistas astronautas alrededor de anillos planetarios, recoge polvo estelar, aprovecha el rebufo y acelera en la Orbital Cup.
+  - Creador: [Crayon](https://x.com/usecrayon)
+  - Plataforma: Navegador en Crayon; teclado y controles táctiles documentados. La página pública ofrece carreras, contrarreloj y paseo infinito.
+  - GPT-6 Astra: [X](https://x.com/usecrayon/status/2097468975995302167) — Crayon acredita a GPT-6 Astra, Crayon Pro y Three.js por el juego de ciclismo espacial. [Notas de verificación](assets/screenshots/crayon-space-bike/SOURCE.md).
+  - Vista previa: ![Ciclistas astronautas en un anillo planetario, con indicadores de vueltas, posición y polvo estelar.](assets/screenshots/crayon-space-bike/gameplay.jpg)
+
+- **[One More Vine — Into the Wild](https://onemorevine.bennash.dev/)** — Corre, salta y balancéate por cuatro niveles de jungla, recoge tesoros y evita cocodrilos mientras mejoras tu tiempo.
+  - Creador: [Ben Nash](https://x.com/bennash)
+  - Plataforma: Navegador, teclado y controles de movimiento en pantalla; el primer nivel y las instrucciones cargaron sin iniciar sesión.
+  - GPT-6 Astra: [X](https://x.com/bennash/status/2096282758930645170) — El creador lo describe explícitamente como un juego de cuatro niveles inspirado en Pitfall y hecho con GPT-6 Astra. [Notas de verificación](assets/screenshots/one-more-vine/SOURCE.md).
+  - Vista previa: ![Nivel de plataformas selvático con lianas, tesoros, fosos y cocodrilos.](assets/screenshots/one-more-vine/gameplay.jpg)
+
 - **[混合马里奥Ⅱ · 忍者龙剑传 × 坦克大战 / Mario Mix II](https://aha-xiaoq.github.io/games/mario-mix-2/play.html)** — Recorre el mundo subterráneo 1-2 de Mario con Ryu Hayabusa de Ninja Gaiden y el tanque de Battle City: saltos, escalada y combates de desplazamiento lateral con Ryu, batallas con vista cenital con el tanque, o un relevo de ninja a tanque para rescatar a la princesa.
   - Creador: [在下_小Q（Aha-xiaoQ）](https://github.com/Aha-xiaoQ)
   - Plataforma: Navegador de escritorio, interfaz en chino, teclado recomendado; gratis, sin iniciar sesión ni instalar nada.
@@ -349,6 +544,37 @@ Parkour, desafíos de plataformas, carreras y juegos centrados en el movimiento 
   - Derechos: Juego de fans no oficial; los personajes, las imágenes y la música clásicos conservan los derechos de sus respectivos titulares. Consulta los créditos de los materiales en la página del juego original.
   - Vista previa: ![Mario Mix II — portada de vídeo facilitada por el creador, no una captura de la partida.](https://aha-xiaoq.github.io/games/mario-mix-2/cover.jpg)
   - Captura de pantalla: ![El tanque de Mario Mix II dispara en la entrada del mundo 1-2; versión 1.0 en ejecución, capturada el 2026-09-09.](assets/screenshots/mario-mix-2/gameplay.jpg)
+
+- **[Bengaluru ORR Rush](https://orr-rush-bengaluru.ravitheja.chatgpt.site/)** — Compite entre el tráfico de Bengaluru, evita baches y motos de reparto, y usa el impulso o un movimiento lateral para abrirte paso.
+  - Creador: [Ravi Theja](https://x.com/ravithejads)
+  - Plataforma: Navegador de escritorio; teclado con acelerador automático opcional, sin iniciar sesión.
+  - GPT-6 Astra: [Declaración del creador](https://x.com/ravithejads/status/2097181044625887392) — El creador atribuye el juego de carreras por Bengaluru a GPT-6 Astra. [Notas de verificación](assets/screenshots/bengaluru-orr-rush/SOURCE.md).
+  - Vista previa: ![Coche azul del jugador entre el tráfico de Bengaluru, con posición, velocidad, cronómetro y controles.](assets/screenshots/bengaluru-orr-rush/gameplay.jpg)
+
+- **[SKICROSS — Alpine Downhill](https://iamsonic.net/2026/mini-games/skicross.html)** — Compite contra tres esquiadores montaña abajo, supera puertas y obstáculos, y mantente por delante de la avalancha.
+  - Creador: [Sonic的奇思妙想](https://x.com/sonic0828)
+  - Plataforma: Navegador de escritorio; A/D para girar, Espacio para saltar y Shift para impulsar; sin iniciar sesión ni descargar nada.
+  - GPT-6 Astra: [Declaración del creador](https://x.com/sonic0828/status/2097601232877781344) — El creador atribuye la colección de minijuegos a GPT-6 Astra y presenta este juego de esquí en una respuesta específica. [Notas de verificación](assets/screenshots/skicross/SOURCE.md).
+  - Recursos: [Enlace de lanzamiento del creador](https://x.com/sonic0828/status/2097601732297814300)
+  - Vista previa: ![Cuatro esquiadores en una pista nevada, con bonificación de puerta, clasificación, velocidad y distancia a la avalancha.](assets/screenshots/skicross/gameplay.jpg)
+
+- **[Itsy Bitsy Spider · One More Climb](https://game-bench.piccini.app/games/gpt-6-astra/)** — Trepa por una pared musgosa, atrapa moscas para recuperar el agarre y escóndete en refugios antes de que la lluvia arrastre a la araña.
+  - Creador: [Luiz Piccini](https://piccini.app/)
+  - Plataforma: Navegador; gratis, sin iniciar sesión. WASD o joystick en pantalla.
+  - GPT-6 Astra: [Game Bench del creador](https://game-bench.piccini.app/) — Game Bench identifica este juego publicado como GPT-6 Astra canary, high, fechado 2026-09-05 y creado a partir de su propuesta compartida de juego. [Notas de verificación](assets/screenshots/itsy-bitsy-spider/SOURCE.md).
+  - Vista previa: ![Araña a dos metros en una pared de ladrillo musgosa, con agarre, moscas, refugio y joystick.](assets/screenshots/itsy-bitsy-spider/gameplay.jpg)
+
+- **[Desi Mayhem](https://desimayhem.com/)** — Compite en moto entre el tráfico urbano de India, esquivando autobuses y mototaxis mientras usas patadas, puñetazos e impulsos.
+  - Creador: [Kishore](https://x.com/GetKishore)
+  - Plataforma: Navegador de escritorio; gratis, sin cuenta. Acepta o edita el apodo generado antes de la primera carrera.
+  - GPT-6 Astra: [Hilo de desarrollo del creador](https://x.com/GetKishore/status/2097906401159102811) — Kishore describe iteraciones del juego 3D hecho con Astra mediante referencias callejeras y pruebas repetidas del tráfico, los choques y el combate entre pilotos. [Notas de verificación](assets/screenshots/desi-mayhem/SOURCE.md).
+  - Vista previa: ![Carrera de motos en Chennai con el piloto, tráfico, minimapa, posición y cronómetro.](assets/screenshots/desi-mayhem/gameplay.jpg)
+
+- **[Cosmic Tides](https://app.usecrayon.ai/play/362ae1e7-29bd-4fbc-9103-00649265d942)** — Pilota una nave sobre un océano galáctico, sigue puertas luminosas y elige una carrera de dos vueltas o una deriva infinita.
+  - Creador: [Aniket J](https://x.com/aniketjart)
+  - Plataforma: Navegador; espera a los recursos 3D y pulsa Ride the current. Gratis, sin iniciar sesión.
+  - GPT-6 Astra: [X](https://x.com/aniketjart/status/2098207146647433534) — Aniket acredita a GPT-6 Astra, Blender MCP y Crayon; describe un experimento con más iteraciones de jugabilidad previstas. [Notas de verificación](assets/screenshots/cosmic-tides/SOURCE.md).
+  - Vista previa: ![Carrera de Cosmic Tides acercándose a una puerta luminosa sobre un mar galáctico, con vueltas y velocidad.](assets/screenshots/cosmic-tides/gameplay.jpg)
 
 <a id="experimental-multiplayer"></a>
 
@@ -394,6 +620,12 @@ Mecánicas inusuales, competición en línea y experiencias cooperativas.
   - Plataforma: Navegador, gratis, sin cuenta. El creador indica que puede requerir VPN/proxy. Inicio individual verificado; multijugador no probado.
   - GPT-6 Astra: [Issue #52](https://github.com/MartinDelophy/awesome-gpt-6-astra/issues/52) — Según el creador: Primera versión con GPT-6 Astra Pro; mejoras posteriores con GPT-6 Astra en Codex.
   - Vista previa: ![泡泡坦克大作战联机版 / Toon Tank Arena](https://github.com/user-attachments/assets/713d44f3-a77c-452c-ba6d-1231882dc670)
+
+- **[Above the Rooftops](https://app.usecrayon.ai/play/d09bb865-2259-42e2-86cc-fb609a9d6f28)** — Pinta una cometa y vuela sobre los tejados, equilibrando la tensión del hilo en vuelo libre o en un reto cronometrado de luces del cielo.
+  - Creador: [Tushar / @TusharXo](https://x.com/TusharXo)
+  - Plataforma: Navegador; elige un personaje, entra en la azotea y pulsa Fly. Gratis, sin iniciar sesión.
+  - GPT-6 Astra: [X](https://x.com/TusharXo/status/2098156783181467801) — Tushar acredita explícitamente a GPT-6 Astra y Crayon por el juego de cometas en Three.js, y menciona Images 2.5 para los gráficos. [Notas de verificación](assets/screenshots/above-the-rooftops/SOURCE.md).
+  - Vista previa: ![Reto de cometa sobre la ciudad, con altura, tensión del hilo, progreso de luces y controles de dirección.](assets/screenshots/above-the-rooftops/gameplay.jpg)
 
 ## Qué incluye cada entrada
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -4,7 +4,7 @@
 
 # Awesome GPT-6 Astra
 
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](CONTRIBUTING.md) [![LINUX DO](https://img.shields.io/badge/LINUX%20DO-Community-f0b73f?style=flat-square)](https://linux.do/) [![Cases: 49](https://img.shields.io/badge/Cases-49-58a6ff?style=flat-square)](https://astragames.aigccreative.com/)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](CONTRIBUTING.md) [![LINUX DO](https://img.shields.io/badge/LINUX%20DO-Community-f0b73f?style=flat-square)](https://linux.do/) [![Cases: 86](https://img.shields.io/badge/Cases-86-58a6ff?style=flat-square)](https://astragames.aigccreative.com/)
 
 **Une sélection de jeux intéressants créés avec GPT-6 Astra.**
 
@@ -22,7 +22,7 @@ Cette page traduit le [README anglais](README.md). Consultez l’original pour v
 
 ## Pour commencer
 
-Découvrez **49 jeux et projets interactifs** : stratégie territoriale des Trois Royaumes, puzzles en bois à emboîtement et à glissement, fusion de fruits déformables, vol à une touche, combats sur tapis volant, défense d’île par un réseau électrique, survie en pleine nature, pêche sous-marine, gestion d’un restaurant de sushis et agriculture insulaire, course de karts sur Bay Circuit, balade côtière à vélo avec un pélican, jouets de table adaptés en 3D et Orbital Garden. Cliquez sur un titre pour jouer directement dans le navigateur.
+Découvrez **86 jeux et projets interactifs** : stratégie territoriale des Trois Royaumes, puzzles en bois à emboîtement et à glissement, fusion de fruits déformables, 2048 de construction urbaine avec génération procédurale, vol à une touche, combats sur tapis volant, un jeu de tir à rideaux de balles en cinq niveaux, défense d’île par un réseau électrique, survie en pleine nature, pêche sous-marine, gestion d’un restaurant de sushis et agriculture insulaire, course de karts sur Bay Circuit, balade côtière à vélo avec un pélican, jouets de table adaptés en 3D, décoration intérieure en 3D et Orbital Garden. Cliquez sur un titre pour jouer directement dans le navigateur.
 
 Mise à jour du catalogue : **2026-09-12**. L’utilisation du modèle est renseignée d’après les déclarations des créateurs ou des contributeurs ; les points non confirmés sont signalés dans chaque fiche. Cette date correspond à la maintenance du catalogue, pas à un nouveau test de tous les jeux.
 
@@ -110,6 +110,70 @@ Jeux de tir, de combat, de survie, de rythme et tous ceux qui donnent envie de r
   - GPT-6 Astra: [X](https://x.com/jumperz/status/2096600055301984738) — Le créateur indique avoir utilisé Astra pour développer ce projet. [Notes de vérification (anglais)](assets/screenshots/cinderfall/SOURCE.md).
   - Aperçu: ![Cinderfall · Fire, Shadow & Steel](assets/screenshots/cinderfall/gameplay.jpg)
 
+- **[Oz Breakdance](https://satriodewantono.com/breakdance/)** — Déplacez les membres d’un danseur articulé vers les cibles correspondantes pour marquer des points et prolonger une manche de breaking chronométrée.
+  - Créateur: [Satrio](https://x.com/satrio_d)
+  - Plateforme: Navigateur sur ordinateur, souris ; une manche chronométrée a été lancée sans connexion à un compte.
+  - GPT-6 Astra: [X](https://x.com/satrio_d/status/2096022866097758500) — Le créateur indique qu’Astra a amélioré son jeu de breakdance existant et sa présentation. [Notes de vérification](assets/screenshots/breakdance/SOURCE.md).
+  - Aperçu: ![Un danseur articulé vise une cible avec le pied dans l’arène de breakdance chronométrée.](assets/screenshots/breakdance/gameplay.jpg)
+
+- **[Astral War](https://astralwar.io/)** — Un FPS de navigateur sur le thème de la Seconde Guerre mondiale, avec apparences de soldats et de zombies, équipements d’armes, entraînement contre des bots et options de salon.
+  - Créateur: [Rishi](https://x.com/0xRishi)
+  - Plateforme: Navigateur sur ordinateur, clavier et souris ; entraînement contre des bots lancé sans compte. Multijoueur et manette non testés.
+  - GPT-6 Astra: [X](https://x.com/0xRishi/status/2096079660605997264) — Rishi indique avoir créé Astral War avec Astra, Three.js, Meshy et ElevenLabs. Le site actuel crédite également Vesper ; voir la note d’attribution. [Notes de vérification](assets/screenshots/astral-war/SOURCE.md).
+  - Aperçu: ![Vue de combat d’Astral War avec l’arme et les commandes du champ de bataille.](assets/screenshots/astral-war/gameplay.jpg)
+
+- **[FLOP CLUB](https://bubucn.com/ai-model-evals/flop-club/game/index.html)** — Plongez depuis trois hauteurs, réalisez saltos et vrilles, puis visez un anneau flottant pour améliorer votre score d’entrée dans l’eau.
+  - Créateur: [BubuAi](https://x.com/BubuStd)
+  - Plateforme: Navigateur ; le jeu autonome démarre sans compte ni téléchargement. Un plongeon a été lancé lors du contrôle du 2026-09-09 ; clavier et commandes tactiles documentées.
+  - GPT-6 Astra: [X](https://x.com/BubuStd/status/2096402783805354091) — Le créateur annonce une réalisation avec Astra Pro et Three.js à partir d’un seul prompt. [Notes de vérification](assets/screenshots/flop-club/SOURCE.md).
+  - Ressources: [Présentation du projet](https://bubucn.com/zh/ai-model-evals/flop-club)
+  - Aperçu: ![Un plongeur sur la plateforme haute, au-dessus de l’anneau cible et des commandes d’entrée dans l’eau.](assets/screenshots/flop-club/gameplay.jpg)
+
+- **[Vector Dive — Beyond the Signal](https://vector-dive.openai.chatgpt.site/)** — Pilotez sur des circuits filaires au néon qui accélèrent à chaque boucle, en synchronisant accélérations et changements de phase pour survivre plus longtemps.
+  - Créateur: [Thomas Ricouard](https://x.com/Dimillian)
+  - Plateforme: Navigateur sur ordinateur ; un vol avec score a été lancé sans compte. WASD pour voler, Espace pour accélérer et Shift pour changer de phase.
+  - GPT-6 Astra: [X](https://x.com/Dimillian/status/2097188900888322323) — Le créateur indique qu’Astra a produit le jeu et la musique à partir d’un brief visuel néon/synthwave et d’illustrations conceptuelles. [Notes de vérification](assets/screenshots/vector-dive/SOURCE.md).
+  - Aperçu: ![Parcours de vol au néon de Vector Dive avec le vaisseau et les indicateurs de jeu.](assets/screenshots/vector-dive/gameplay.jpg)
+
+- **[Harbor Skirmish](https://gpt6astra-game.vercel.app/)** — Défendez une ville côtière contre des vagues de lapins turbulents avec trois armes, des passages sur les toits, des ruées et un grappin.
+  - Créateur: [OpenDesign](https://x.com/OpenDesignHQ)
+  - Plateforme: Navigateur sur ordinateur ; clavier et souris, sans compte ni téléchargement.
+  - GPT-6 Astra: [Déclaration du créateur](https://x.com/OpenDesignHQ/status/2097635757917983223) — OpenDesign identifie ce jeu Three.js comme la version GPT-6 Astra dans sa comparaison de deux modèles. [Notes de vérification](assets/screenshots/harbor-skirmish/SOURCE.md).
+  - Aperçu: ![Vue à la première personne avec un fusil à Seabreeze, des lapins approchants, un compteur de vagues et les commandes d’armes.](assets/screenshots/harbor-skirmish/gameplay.jpg)
+
+- **[UNDERGROUND — Underground Boxing](https://iamsonic.net/2026/mini-games/underground-boxing.html)** — Boxez durant trois rounds chronométrés dans un ring souterrain en 3D, en dosant coups, gardes, esquives et endurance.
+  - Créateur: [Sonic的奇思妙想](https://x.com/sonic0828)
+  - Plateforme: Navigateur sur ordinateur ; WASD pour bouger, J/K pour frapper, L pour bloquer et Espace pour esquiver ; sans compte ni téléchargement.
+  - GPT-6 Astra: [Déclaration du créateur](https://x.com/sonic0828/status/2097601232877781344) — Le fil de présentation du créateur cite GPT-6 Astra pour la génération des mini-jeux ; la réponse consacrée à la boxe renvoie vers cette version. [Notes de vérification](assets/screenshots/underground-boxing/SOURCE.md).
+  - Ressources: [Lien de lancement du créateur](https://x.com/sonic0828/status/2097601584410796401)
+  - Aperçu: ![Deux boxeurs échangent des coups dans un ring souterrain éclairé, avec chronomètre, santé et endurance.](assets/screenshots/underground-boxing/gameplay.jpg)
+
+- **[Urban Champion 3D](https://iamsonic.net/2026/mini-games/urban-champion.html)** — Alternez coups hauts et bas dans une rue au couchant, bloquez les ripostes et poussez l’adversaire dans une bouche d’égout en évitant les pots de fleurs qui tombent.
+  - Créateur: [Sonic的奇思妙想](https://x.com/sonic0828)
+  - Plateforme: Navigateur sur ordinateur ; A/D pour bouger, J/K pour frapper, U/I pour bloquer et Espace pour esquiver ; sans compte.
+  - GPT-6 Astra: [Déclaration du créateur](https://x.com/sonic0828/status/2097601232877781344) — La présentation GPT-6 Astra du créateur comporte une réponse de lancement distincte qui renvoie vers ce jeu de combat de rue. [Notes de vérification](assets/screenshots/urban-champion-3d/SOURCE.md).
+  - Ressources: [Lien de lancement du créateur](https://x.com/sonic0828/status/2097601861658587376)
+  - Aperçu: ![Combattants bleu et rouge devant Sunset Mart, avec chronomètre du round et jauges d’endurance.](assets/screenshots/urban-champion-3d/gameplay.jpg)
+
+- **[Zero District — Shells 3D](https://iamsonic.net/2026/mini-games/shells-3d/play.html)** — Survivez à un siège urbain de trois minutes grâce au tir automatique, aux esquives en mouvement, à l’expérience à ramasser et aux améliorations à choisir.
+  - Créateur: [Sonic的奇思妙想](https://x.com/sonic0828)
+  - Plateforme: Navigateur ; WASD ou glissement pour bouger, visée automatique ; sans compte ni téléchargement.
+  - GPT-6 Astra: [Déclaration du créateur](https://x.com/sonic0828/status/2097601232877781344) — Le créateur nomme GPT-6 Astra dans l’annonce de la collection et propose cette version de survie 3D dans une réponse dédiée. [Notes de vérification](assets/screenshots/zero-district-shells-3d/SOURCE.md).
+  - Ressources: [Lien de lancement du créateur](https://x.com/sonic0828/status/2097602391122264310)
+  - Aperçu: ![Un survivant tire automatiquement sur les ennemis d’une rue, avec 14 éliminations et 166 secondes restantes.](assets/screenshots/zero-district-shells-3d/gameplay.jpg)
+
+- **[ASCII DISTRICT](https://ascii-district.vercel.app/)** — Affrontez des vagues de virus informatiques dans une arène à la première personne dessinée en caractères ASCII, avec sprint, saut et glissade.
+  - Créateur: [Acker Code](https://x.com/acker_code)
+  - Plateforme: Navigateur sur ordinateur ; clavier et souris, sans compte. Cliquez dans l’arène pour capturer la souris ; Échap la libère.
+  - GPT-6 Astra: [Déclaration du créateur](https://x.com/acker_code/status/2097542957070975286) — Le créateur crédite explicitement Codex et GPT-6 Astra pour ce jeu de tir en art ASCII. [Notes de vérification](assets/screenshots/ascii-district/SOURCE.md).
+  - Aperçu: ![Cour ASCII envahie par des virus, avec 29 cartouches indiquées après un tir.](assets/screenshots/ascii-district/gameplay.jpg)
+
+- **[Aura Farming: Unbothered](https://www.aigameshare.com/games/aura-farming-game)** — Gardez un capybara dansant en équilibre sur un bateau-dragon, penchez-vous contre les vagues et réussissez six figures en 40 secondes.
+  - Créateur: [nilni / @nil](https://www.aigameshare.com/profile/nil)
+  - Plateforme: Navigateur sur ordinateur ; jeu gratuit sans compte. Cliquez sur Play ; les fonctions de compte sont facultatives.
+  - GPT-6 Astra: [Fiche du créateur](https://www.aigameshare.com/games/aura-farming-game) — Le créateur crédite GPT-6 Astra et Codex, ainsi que Blender, Three.js, ImageGen et WebAudio. [Notes de vérification](assets/screenshots/aura-farming/SOURCE.md).
+  - Aperçu: ![Un capybara danse sur un bateau-dragon, avec commandes d’inclinaison et d’appui et défi de six figures.](assets/screenshots/aura-farming/gameplay.jpg)
+
 <a id="puzzles"></a>
 
 ### Casse-têtes et réflexion
@@ -135,6 +199,25 @@ Jeux de tir, de combat, de survie, de rythme et tous ceux qui donnent envie de r
   - Participation du modèle: [Journal de création](works/sunjing-puzzles/CREATION.md) — Travail itératif dans Codex sur la conception du jeu, les visuels 3D procéduraux, les règles, le solveur et les tests ; l’utilisation exacte de GPT-6 Astra attend la confirmation du créateur (soumission provisoire).
   - Ressources: [Code source et instructions de lancement](works/sunjing-puzzles/README.md) · [Demandes](works/sunjing-puzzles/PROMPTS.md) · Technologies: React, Vinext/Vite, Three.js.
   - Aperçu: ![Casse-tête en bois à six pièces de Sunjing sur un établi 3D vert, avec les numéros des pièces et les commandes d’extraction.](assets/screenshots/sunjing-puzzles/gameplay.jpg)
+
+- **[CityMaker](https://citymaker.0to1app.com)** — Un puzzle 2048 sur un quartier de 4×4 cases : fusionnez les bâtiments identiques pour parcourir onze niveaux architecturaux par ville, des maisons traditionnelles à une silhouette urbaine reconnaissable, dans douze villes avec rotation par pas de 45°.
+  - Créateur: [Derek Wang](https://github.com/derek-wangpch)
+  - Plateforme: Navigateurs sur ordinateur et mobile avec WebGL ; anglais, chinois simplifié et traditionnel. Gratuit, sans compte ni clé API ; progression par ville dans le navigateur actuel et installation possible sur l’écran d’accueil iOS.
+  - GPT-6 Astra: [Historique de création](https://github.com/derek-wangpch/OpenCityMaker/blob/master/docs/CREATION.md) — Le créateur indique avoir utilisé GPT-6 Astra pour la géométrie procédurale des 132 bâtiments, via références, recherche multivue, volumes fondés sur les silhouettes et validation par captures ; ce n’est pas un essai en un seul prompt.
+  - Ressources: [Code et installation](https://github.com/derek-wangpch/OpenCityMaker) · [Notes de vérification](https://github.com/derek-wangpch/OpenCityMaker/blob/master/QA.md) · Technologies : React, TypeScript, Vite et Three.js ; les 132 modèles de bâtiments sont des géométries procédurales originales.
+  - Aperçu: ![Plateau de Hong Kong de CityMaker : bâtiments 3D low-poly sur grille 4×4, score, sélection des villes et rotation.](assets/screenshots/citymaker/gameplay.png)
+
+- **[Bonkshot](https://bonkshot.com/)** — Tendez un lance-pierre et projetez de petits Bonkers contre des supports en bois pour renverser les structures et éliminer les cibles.
+  - Créateur: [edmund5](https://x.com/edmund5)
+  - Plateforme: Navigateur ; glissez pour viser, relâchez pour tirer. Jouable sans compte ; connexion Google facultative.
+  - GPT-6 Astra: [Déclaration du créateur](https://x.com/edmund5/status/2097603093819261002) — Le créateur crédite GPT-6 Astra et Three.js pour le jeu, et Suno pour la musique de fond. [Notes de vérification](assets/screenshots/bonkshot/SOURCE.md).
+  - Aperçu: ![Premier puzzle de Grasslands après un tir : tour partiellement effondrée, une cible restante et 2 200 points.](assets/screenshots/bonkshot/gameplay.jpg)
+
+- **[Greenhouse Escape Room: The Last Seed](https://www.aigameshare.com/games/greenhouse-escape-room)** — Explorez une serre scellée, réparez des conduites d’eau en cuivre, disposez plantes et lumière réfléchie, et sauvez sa dernière graine.
+  - Créateur: [nilni / @nil](https://www.aigameshare.com/profile/nil)
+  - Plateforme: Navigateur ; cliquez sur Play puis Begin. Gratuit, sans compte ; commandes en anglais et chinois.
+  - GPT-6 Astra: [Fiche du créateur](https://www.aigameshare.com/games/greenhouse-escape-room) — Le créateur cite GPT-6 Astra et Codex comme outils de développement, avec ImageGen et WebAudio. [Notes de vérification](assets/screenshots/greenhouse-escape-room/SOURCE.md).
+  - Aperçu: ![Salle Waterworks de la serre, avec dispositif de tuyaux à neuf cases, chronomètre et inventaire.](assets/screenshots/greenhouse-escape-room/gameplay.jpg)
 
 <a id="strategy-simulation"></a>
 
@@ -227,6 +310,24 @@ Défense de tours, cartes stratégiques, gestion, construction et bacs à sable 
   - Ressources: [GitHub](https://github.com/LucasMarquesShiva/the-free-game)
   - Aperçu: ![The Free Game](assets/screenshots/the-free-game/gameplay.jpg)
 
+- **[AGI of Empires — The Compute Wars](https://agiofempires.com/)** — Récoltez financements et GPU, construisez centres de données et armées, puis devancez les laboratoires d’IA vers l’ASI ou détruisez leurs quartiers généraux.
+  - Créateur: [timour kosters](https://x.com/timourxyz)
+  - Plateforme: Navigateur sur ordinateur ; stratégie en temps réel satirique gratuite. Début de partie contre l’ordinateur et collecte de ressources vérifiés sans compte.
+  - GPT-6 Astra: [X](https://x.com/timourxyz/status/2096662786692776293) — Le créateur explique avoir développé en deux jours avec Astra ce jeu inspiré d’Age of Empires. [Notes de vérification](assets/screenshots/agi-of-empires/SOURCE.md).
+  - Aperçu: ![Champ de bataille d’AGI of Empires, compteurs de ressources et quartier général.](assets/screenshots/agi-of-empires/gameplay.jpg)
+
+- **[Atlas Go](https://atlas-go.borisxp.chatgpt.site/)** — Jouez au go sur des réseaux de rues et des graphes inhabituels, avec jeu local à tour de rôle sur le même appareil et options entre amis.
+  - Créateur: [Boris Power](https://x.com/BorisMPower)
+  - Plateforme: Navigateur ; plateau local ouvert sans compte. Parties en ligne entre amis non testées.
+  - GPT-6 Astra: [X](https://x.com/BorisMPower/status/2096784808399843582) — Le créateur décrit ce go multijoueur sur graphes arbitraires comme une création d’Astra en un seul prompt. [Notes de vérification](assets/screenshots/atlas-go/SOURCE.md).
+  - Aperçu: ![Pierres noires et blanches sur le graphe en nid d’abeille d’Atlas Go.](assets/screenshots/atlas-go/gameplay.jpg)
+
+- **[Ironwood — The Art of Industry](https://ironwood.sparkles.dev/)** — Collectez des matières premières, alimentez les machines et reliez des convoyeurs pour transformer une clairière en usine opérationnelle.
+  - Créateur: [Dan](https://x.com/aidaniil)
+  - Plateforme: Navigateur sur ordinateur ; tutoriel invité accessible sans compte, mais sauvegarde nécessitant une connexion à un compte. Multijoueur non vérifié indépendamment.
+  - GPT-6 Astra: [X](https://x.com/aidaniil/status/2096426970930106530) — Le créateur indique l’avoir construit avec son frère à l’aide d’Astra, Blender MCP et Cloudflare Durable Objects, en s’inspirant de Satisfactory et Besiege. [Notes de vérification](assets/screenshots/ironwood/SOURCE.md).
+  - Aperçu: ![Machines, convoyeurs et tutoriel de gestion des ressources d’Ironwood.](assets/screenshots/ironwood/gameplay.jpg)
+
 - **[DUST FRONT](https://dust-front.mustafaakin.dev/)** — Un RTS solo avec construction de base, capture de positions et commandement des forces terrestres et aériennes.
   - Créateur: [Mustafa Akın](https://x.com/mustafaakin)
   - Plateforme: Navigateur de bureau ; clavier et souris, sans connexion obligatoire.
@@ -239,6 +340,18 @@ Défense de tours, cartes stratégiques, gestion, construction et bacs à sable 
   - GPT-6 Astra: [X](https://x.com/HDLhN783wtLkpPR/status/2097321360641122393) — Dans la publication liée, le créateur indique avoir utilisé « GPT Astra » pour réaliser ce jeu de stratégie en temps réel ; la version exacte du modèle et le processus détaillé ne sont pas précisés.
   - Références: [Soumission](https://github.com/MartinDelophy/awesome-gpt-6-astra/issues/66) · [Notes de vérification (anglais)](assets/screenshots/frontline-command/SOURCE.md)
   - Aperçu: ![Frontline Command : base, trois chars sélectionnés et placement d’une centrale pendant une partie ; v0.8, capture du 2026-09-09.](assets/screenshots/frontline-command/gameplay.jpg)
+
+- **[Coin Pusher Roguelite: Mintfall](https://www.aigameshare.com/games/coin-pusher-roguelite-mintfall)** — Visez avec un pousse-pièces 3D, combinez pièces spéciales et reliques, et terminez six manches avec un nombre limité de lâchers et des objectifs de score.
+  - Créateur: [nilni / @nil](https://www.aigameshare.com/profile/nil)
+  - Plateforme: Navigateur ; cliquez sur Play, gratuit et sans compte. Sauvegardes de compte facultatives.
+  - GPT-6 Astra: [Fiche du créateur](https://www.aigameshare.com/games/coin-pusher-roguelite-mintfall) — Le créateur crédite GPT-6 Astra aux côtés de GPT-5.6 Sol et Codex ; la fiche ne distingue pas leurs contributions. [Notes de vérification](assets/screenshots/mintfall/SOURCE.md).
+  - Aperçu: ![Plateau 3D de Mintfall à la manche 1, avec 33 points, 44 lâchers et commandes des pièces spéciales.](assets/screenshots/mintfall/gameplay.jpg)
+
+- **[Westward — The Oregon Trail](https://biswaz.me/westward/)** — Guidez une caravane vers l’ouest, rationnez les vivres, gérez réparations et chasse, et prenez des décisions sur la piste de l’Oregon.
+  - Créateur: [Biswas](https://x.com/bis_waz)
+  - Plateforme: Navigateur sur ordinateur ; commencez avec le groupe fictif proposé, sans compte ni installation.
+  - GPT-6 Astra: [X](https://x.com/bis_waz/status/2098023593468907747) — Biswas indique avoir utilisé GPT-6 Astra pour cette version moderne en 3D de The Oregon Trail et fournit le lien jouable. [Notes de vérification](assets/screenshots/westward/SOURCE.md).
+  - Aperçu: ![Chariot et bœufs en route vers la Kansas River, avec 25 miles parcourus et panneau de provisions.](assets/screenshots/westward/gameplay.jpg)
 
 <a id="rpg-adventures"></a>
 
@@ -276,6 +389,63 @@ Jeux de rôle, exploration, aventures narratives et histoires interactives.
   - Plateforme: Navigateur de bureau ; ouvert sans connexion ni paiement. Mobile non testé.
   - GPT-6 Astra: [X](https://x.com/emollick/status/2096047660662722620) — Le créateur indique avoir utilisé Astra pour développer ce projet. [Notes de vérification (anglais)](assets/screenshots/zork/SOURCE.md).
   - Aperçu: ![Zork · The Great Underground Empire](assets/screenshots/zork/gameplay.jpg)
+
+- **[The Simpsons: Hit & Run — Browser Recreation](https://vheissu.github.io/hit-and-run-web/)** — Explorez Springfield à pied et en voiture dans une recréation non officielle pour navigateur, avec missions, circulation et poursuites policières.
+  - Créateur: [Dwayne](https://x.com/CtrlAltDwayne)
+  - Plateforme: Navigateur sur ordinateur ; première mission chargée sans compte après un important chargement initial de ressources. Campagne complète non testée.
+  - GPT-6 Astra: [X](https://x.com/CtrlAltDwayne/status/2096872309936287887) — Le créateur décrit la reconstruction pour le Web avec GPT-6 Astra ; le dépôt crédite aussi Claude pour une aide au chargement. Les ressources du jeu original conservent leurs droits. [Notes de vérification](assets/screenshots/hit-and-run-web/SOURCE.md).
+  - Ressources: [Code et installation](https://github.com/Vheissu/hit-and-run-web)
+  - Aperçu: ![Homer à Springfield, avec objectif de la première mission et mini-carte.](assets/screenshots/hit-and-run-web/gameplay.jpg)
+
+- **[Where the Wind Wanders](https://app.usecrayon.ai/play/a9a3c165-74b3-4ff6-9588-ad97f829ddb5)** — Parcourez une vallée ensoleillée en 2.5D, suivez les sentiers et rassemblez trois lettres du vent dans une aventure d’exploration paisible.
+  - Créateur: [Tushar](https://x.com/TusharXo)
+  - Plateforme: Navigateur, hébergement Crayon ; page publique et lecteur intégré vérifiés.
+  - GPT-6 Astra: [X](https://x.com/TusharXo/status/2096037482739683574) — Tushar décrit Astra générant sentiers et ressources ; une annonce ultérieure présente la version jouable avec Astra, Three.js et Crayon. [Notes de vérification](assets/screenshots/crayon-adventure/SOURCE.md).
+  - Ressources: [Annonce de lancement du créateur](https://x.com/TusharXo/status/2096741535891251261)
+  - Aperçu: ![Un personnage explore une vallée fleurie, avec l’objectif des lettres du vent visible.](assets/screenshots/crayon-adventure/gameplay.jpg)
+
+- **[ALIBI — The Last Light](https://alibi-blackthorn-manor.vercel.app/)** — Enquêtez à Blackthorn Manor dans un mystère policier en pointer-cliquer : examinez les scènes et suivez les indices pour identifier le meurtrier.
+  - Créateur: [Christos Antonopoulos](https://x.com/Christos_antono)
+  - Plateforme: Navigateur ; entrée interactive du manoir ouverte sans compte. Scènes générées ultérieures non testées intégralement.
+  - GPT-6 Astra: [X](https://x.com/Christos_antono/status/2096435122669297892) — Le créateur crédite GPT Astra et H3 Max pour ce jeu d’enquête génératif. [Notes de vérification](assets/screenshots/alibi-blackthorn-manor/SOURCE.md).
+  - Aperçu: ![Entrée du manoir avec porte cliquable et texte initial de l’enquête.](assets/screenshots/alibi-blackthorn-manor/gameplay.jpg)
+
+- **[Skyward: The Gathering](https://edge-city-skyward-quests.vercel.app/)** — Explorez des îles flottantes, sautez et planez entre communautés, et accomplissez les quêtes de leurs habitants.
+  - Créateur: [timour kosters](https://x.com/timourxyz)
+  - Plateforme: Navigateur sur ordinateur, clavier et souris ; page et commandes de l’édition avec quêtes vérifiées.
+  - GPT-6 Astra: [X](https://x.com/timourxyz/status/2096379521926840339) — Le créateur indique qu’Astra a réalisé un jeu 3D jouable avec PNJ et quêtes inspirés de lieux d’Edge City. [Notes de vérification](assets/screenshots/skyward-gathering/SOURCE.md).
+  - Aperçu: ![Vue des îles flottantes de Skyward, avec commandes d’exploration et journal.](assets/screenshots/skyward-gathering/gameplay.jpg)
+
+- **[Anna & Leo · The Starstone Adventure](https://anna-leo-starstone.vercel.app/)** — Alternez magie musicale d’Anna et superpouvoirs de Leo pour réveiller les fleurs mélodieuses et explorer Wonder Garden.
+  - Créateur: [Dharma Utomo](https://x.com/dharmautomo)
+  - Plateforme: Navigateur ; quête initiale lancée sans compte. WASD pour bouger, Espace pour sauter, E pour le pouvoir et Tab pour changer de héros.
+  - GPT-6 Astra: [X](https://x.com/dharmautomo/status/2096573649235091967) — Le créateur explique que GPT-6 Astra l’a aidé à construire l’aventure 3D et partage une vidéo de ses enfants la testant. [Notes de vérification](assets/screenshots/anna-leo-starstone/SOURCE.md).
+  - Aperçu: ![Monde d’aventure 3D d’Anna et Leo avec interface de quêtes.](assets/screenshots/anna-leo-starstone/gameplay.jpg)
+
+- **[The Legend of Deller](https://rain-court-js.umodeler-inc-4323.chatgpt.site/)** — Explorez Rainmist Haven et avancez vers des donjons avec combos à l’épée, compétences élémentaires et mouvements d’esquive.
+  - Créateur: [UModeler X PicoBerry](https://x.com/UModeler)
+  - Plateforme: Navigateur sur ordinateur ; clavier et souris, sans compte. Laissez les ressources 3D initiales finir de charger.
+  - GPT-6 Astra: [Déclaration du créateur](https://x.com/UModeler/status/2097792348407099553) — Le créateur indique que PicoBerry a généré les ressources et GPT-6 Astra le RPG d’action Three.js qui les exploite. [Notes de vérification](assets/screenshots/the-legend-of-deller/SOURCE.md).
+  - Ressources: [Lien de lancement du créateur](https://x.com/UModeler/status/2097792351129178451)
+  - Aperçu: ![Deller esquive près d’une fontaine et d’étals à Rainmist Haven, avec santé, mana et compétences.](assets/screenshots/the-legend-of-deller/gameplay.jpg)
+
+- **[Dungeon of Astra](https://wavedash.com/games/dungeon-of-astra)** — Recrutez une équipe, descendez un donjon de cent étages et combinez épées, boules de feu et rôles des compagnons dans une partie à mort permanente.
+  - Créateur: [tonysuri / @tonysurix](https://x.com/tonysurix)
+  - Plateforme: Navigateur sur ordinateur, Wavedash ; jeu de base accessible sans compte. Comptes facultatifs et déblocages anticipés payants de personnages disponibles.
+  - GPT-6 Astra: [Déclaration du créateur](https://x.com/tonysurix/status/2097873333551616355) — Le créateur affirme explicitement que ce jeu d’exploration de donjons en équipe a été créé avec GPT-6 Astra. [Notes de vérification](assets/screenshots/dungeon-of-astra/SOURCE.md).
+  - Aperçu: ![Le héros et un chevalier recruté lancent une boule de feu au premier étage, avec santé du groupe et mini-carte.](assets/screenshots/dungeon-of-astra/gameplay.jpg)
+
+- **[Sunlandia — The Forgotten Shore](https://sunlandia.smallweblab.com/)** — Explorez une île après un naufrage, cherchez des indices à la première personne et résolvez des énigmes environnementales vers le phare.
+  - Créateur: [Ramon Linares / Small Web Lab](https://github.com/RamonLinares)
+  - Plateforme: Navigateur sur ordinateur ; attendez l’île puis cliquez sur Begin expedition. Gratuit, sans compte ni installation.
+  - GPT-6 Astra: [Journal du créateur](https://smallweblab.com/posts/sunlandia/) — Le créateur a commencé avec GPT-5.6 Sol, reçu l’aide de Fable, puis terminé le jeu avec GPT-6 Astra. [Notes de vérification](assets/screenshots/sunlandia/SOURCE.md).
+  - Aperçu: ![Rivage de Sunlandia à la première personne, avec épave, ponton cassé et objectif de chercher de l’aide.](assets/screenshots/sunlandia/gameplay.jpg)
+
+- **[NÁCAR](https://nacar-microcosmo.preda2005.chatgpt.site/)** — Faites grandir un organisme microscopique dans une coquille d’escargot inondée, collectez des nutriments et développez de nouvelles parties du corps en explorant.
+  - Créateur: [Marcio Lima / @Preda2005](https://x.com/Preda2005)
+  - Plateforme: Navigateur ; bêta gratuite sans compte, avec cinq langues d’interface dont le chinois.
+  - GPT-6 Astra: [Fil du créateur](https://x.com/Preda2005/status/2097954217180921928) — Marcio indique avoir décrit cette idée d’évolution d’un organisme à GPT-6 Astra et l’avoir développée jusqu’à la bêta liée. [Notes de vérification](assets/screenshots/nacar/SOURCE.md).
+  - Aperçu: ![Petite cellule parmi des nutriments colorés, avec biomasse, évolution, inventaire et suivi des eaux explorées.](assets/screenshots/nacar/gameplay.jpg)
 
 <a id="platformers-racing"></a>
 
@@ -341,6 +511,31 @@ Parkour, défis de plateforme, courses et jeux centrés sur les déplacements et
   - GPT-6 Astra: [Issue #51](https://github.com/MartinDelophy/awesome-gpt-6-astra/issues/51) — Selon le créateur : Première version avec Qwen3.8 Max, deuxième entièrement reconstruite avec Astra.
   - Aperçu: ![疾风赛道 / Kart Racing（跑跑卡丁车）](https://github.com/user-attachments/assets/015e0ca1-7032-4d0e-9391-ad3f40d84227)
 
+- **[TIDAL RUSH — Paradise GP](https://tidal-rush-paradise-gp.skirano.chatgpt.site/)** — Dérapez sur un circuit tropical de karting, utilisez des objets et affrontez sept rivaux sur trois tours.
+  - Créateur: [Pietro Schirano](https://x.com/skirano)
+  - Plateforme: Navigateur ; course de trois tours lancée sans compte. Conduite, dérapage et objets au clavier, plus boutons tactiles à l’écran.
+  - GPT-6 Astra: [Attribution du modèle](https://openai.com/index/gpt-6-astra/) — La page de lancement d’Astra d’OpenAI renvoie vers ce kart interactif et crédite Pietro Schirano. La publication de découverte sur X vient de la communauté, pas du créateur. [Notes de vérification](assets/screenshots/tidal-rush/SOURCE.md).
+  - Ressources: [Découverte sur X](https://x.com/alexgetmancom/status/2095598460921614825)
+  - Aperçu: ![Circuit tropical de Tidal Rush, avec position de course et commandes de dérapage.](assets/screenshots/tidal-rush/gameplay.jpg)
+
+- **[LUNA — Crimson Requiem / 紅月のレクイエム](https://luna-crimson-requiem.ponsuke.chatgpt.site/)** — Sautez dans un décor gothique en pixel art, tailladez ou écrasez les ennemis, ou invoquez une attaque dans une courte aventure à défilement horizontal.
+  - Créateur: [音羽ぽんすけ](https://x.com/ponsuke_otowa)
+  - Plateforme: Navigateur, interface japonaise ; clavier et prise en charge des smartphones annoncée par le créateur. Un niveau disponible.
+  - GPT-6 Astra: [X](https://x.com/ponsuke_otowa/status/2096531744933425299) — Le créateur mentionne environ 25 minutes de développement avec Astra et une correction de l’animation de marche ; la musique est créditée séparément à Suno. [Notes de vérification](assets/screenshots/luna-crimson-requiem/SOURCE.md).
+  - Aperçu: ![LUNA combat dans une rue gothique sous une lune rouge, avec santé et jauge d’invocation.](assets/screenshots/luna-crimson-requiem/gameplay.jpg)
+
+- **[Strange Orbit](https://app.usecrayon.ai/play/47df78e2-1410-45d1-833c-196e1161c0b8)** — Faites courir des cyclistes astronautes autour d’anneaux planétaires, collectez de la poussière d’étoiles, profitez de l’aspiration et accélérez dans l’Orbital Cup.
+  - Créateur: [Crayon](https://x.com/usecrayon)
+  - Plateforme: Navigateur sur Crayon ; clavier et commandes tactiles documentées. La page publique propose course, contre-la-montre et promenade infinie.
+  - GPT-6 Astra: [X](https://x.com/usecrayon/status/2097468975995302167) — Crayon crédite GPT-6 Astra, Crayon Pro et Three.js pour ce jeu de vélo spatial. [Notes de vérification](assets/screenshots/crayon-space-bike/SOURCE.md).
+  - Aperçu: ![Cyclistes astronautes sur un anneau planétaire, avec tours, classement et poussière d’étoiles.](assets/screenshots/crayon-space-bike/gameplay.jpg)
+
+- **[One More Vine — Into the Wild](https://onemorevine.bennash.dev/)** — Courez, sautez et balancez-vous dans quatre niveaux de jungle, ramassez des trésors et évitez les crocodiles pour améliorer votre temps.
+  - Créateur: [Ben Nash](https://x.com/bennash)
+  - Plateforme: Navigateur, clavier et commandes à l’écran ; niveau initial et instructions chargés sans compte.
+  - GPT-6 Astra: [X](https://x.com/bennash/status/2096282758930645170) — Le créateur le présente explicitement comme un jeu de quatre niveaux inspiré de Pitfall et réalisé avec GPT-6 Astra. [Notes de vérification](assets/screenshots/one-more-vine/SOURCE.md).
+  - Aperçu: ![Niveau de plateformes dans la jungle avec lianes, trésors, fosses et crocodiles.](assets/screenshots/one-more-vine/gameplay.jpg)
+
 - **[混合马里奥Ⅱ · 忍者龙剑传 × 坦克大战 / Mario Mix II](https://aha-xiaoq.github.io/games/mario-mix-2/play.html)** — Explorez le monde souterrain 1-2 de Mario avec Ryu Hayabusa de Ninja Gaiden et le char de Battle City : sauts, escalade et combats en défilement latéral pour Ryu, combats en vue de dessus pour le char, ou relais ninja puis char pour sauver la princesse.
   - Créateur: [在下_小Q（Aha-xiaoQ）](https://github.com/Aha-xiaoQ)
   - Plateforme: Navigateur sur ordinateur, interface en chinois, clavier recommandé ; gratuit, sans connexion ni installation.
@@ -349,6 +544,37 @@ Parkour, défis de plateforme, courses et jeux centrés sur les déplacements et
   - Droits: Jeu de fans non officiel ; les personnages, images et musiques classiques restent la propriété de leurs ayants droit. Les crédits des ressources figurent sur la page du jeu original.
   - Aperçu: ![Mario Mix II — miniature vidéo fournie par le créateur, et non capture de jeu.](https://aha-xiaoq.github.io/games/mario-mix-2/cover.jpg)
   - Capture d’écran: ![Le char de Mario Mix II tire à l’entrée du monde 1-2 ; version 1.0 en cours de jeu, capture du 2026-09-09.](assets/screenshots/mario-mix-2/gameplay.jpg)
+
+- **[Bengaluru ORR Rush](https://orr-rush-bengaluru.ravitheja.chatgpt.site/)** — Foncez dans la circulation de Bengaluru, évitez nids-de-poule et motos de livraison, puis utilisez l’accélération ou un mouvement latéral pour vous frayer un passage.
+  - Créateur: [Ravi Theja](https://x.com/ravithejads)
+  - Plateforme: Navigateur sur ordinateur ; clavier avec accélération automatique facultative, sans compte.
+  - GPT-6 Astra: [Déclaration du créateur](https://x.com/ravithejads/status/2097181044625887392) — Le créateur attribue ce jeu de course routière à Bengaluru à GPT-6 Astra. [Notes de vérification](assets/screenshots/bengaluru-orr-rush/SOURCE.md).
+  - Aperçu: ![Voiture bleue du joueur dans Bengaluru, avec position, vitesse, chronomètre et indications de commandes.](assets/screenshots/bengaluru-orr-rush/gameplay.jpg)
+
+- **[SKICROSS — Alpine Downhill](https://iamsonic.net/2026/mini-games/skicross.html)** — Affrontez trois skieurs en descente, franchissez portes et obstacles, et gardez de l’avance sur l’avalanche.
+  - Créateur: [Sonic的奇思妙想](https://x.com/sonic0828)
+  - Plateforme: Navigateur sur ordinateur ; A/D pour tourner, Espace pour sauter et Shift pour accélérer ; sans compte ni téléchargement.
+  - GPT-6 Astra: [Déclaration du créateur](https://x.com/sonic0828/status/2097601232877781344) — Le créateur attribue la collection de mini-jeux à GPT-6 Astra et fournit ce jeu de ski dans une réponse dédiée. [Notes de vérification](assets/screenshots/skicross/SOURCE.md).
+  - Ressources: [Lien de lancement du créateur](https://x.com/sonic0828/status/2097601732297814300)
+  - Aperçu: ![Quatre skieurs sur une piste enneigée, avec bonus de porte, classement, vitesse et distance de l’avalanche.](assets/screenshots/skicross/gameplay.jpg)
+
+- **[Itsy Bitsy Spider · One More Climb](https://game-bench.piccini.app/games/gpt-6-astra/)** — Grimpez sur un mur moussu, attrapez des mouches pour retrouver de l’adhérence et abritez-vous dans des trous avant que la pluie n’emporte l’araignée.
+  - Créateur: [Luiz Piccini](https://piccini.app/)
+  - Plateforme: Navigateur ; gratuit, sans compte. WASD ou joystick à l’écran.
+  - GPT-6 Astra: [Game Bench du créateur](https://game-bench.piccini.app/) — Game Bench étiquette cette création publiée GPT-6 Astra canary, high, datée du 2026-09-05 et construite à partir de son brief de jeu commun. [Notes de vérification](assets/screenshots/itsy-bitsy-spider/SOURCE.md).
+  - Aperçu: ![Araignée à deux mètres sur un mur de briques moussu, avec adhérence, mouches, abri et joystick.](assets/screenshots/itsy-bitsy-spider/gameplay.jpg)
+
+- **[Desi Mayhem](https://desimayhem.com/)** — Pilotez des motos dans la circulation des villes indiennes, slalomez entre bus et rickshaws et utilisez coups de pied, coups de poing et accélérations.
+  - Créateur: [Kishore](https://x.com/GetKishore)
+  - Plateforme: Navigateur sur ordinateur ; gratuit, sans compte. Acceptez ou modifiez le pseudonyme généré avant la première course.
+  - GPT-6 Astra: [Fil de développement du créateur](https://x.com/GetKishore/status/2097906401159102811) — Kishore décrit les itérations du jeu 3D réalisé avec Astra à partir de références de rues et de tests répétés de circulation, collisions et combats entre pilotes. [Notes de vérification](assets/screenshots/desi-mayhem/SOURCE.md).
+  - Aperçu: ![Course de motos à Chennai avec pilote, circulation, mini-carte, position et chronomètre.](assets/screenshots/desi-mayhem/gameplay.jpg)
+
+- **[Cosmic Tides](https://app.usecrayon.ai/play/362ae1e7-29bd-4fbc-9103-00649265d942)** — Pilotez un engin sur un océan galactique, suivez les portes lumineuses et choisissez une course de deux tours ou une dérive infinie.
+  - Créateur: [Aniket J](https://x.com/aniketjart)
+  - Plateforme: Navigateur ; attendez les ressources 3D puis cliquez sur Ride the current. Gratuit, sans compte.
+  - GPT-6 Astra: [X](https://x.com/aniketjart/status/2098207146647433534) — Aniket crédite GPT-6 Astra, Blender MCP et Crayon ; il décrit une expérience avec de nouvelles itérations de gameplay prévues. [Notes de vérification](assets/screenshots/cosmic-tides/SOURCE.md).
+  - Aperçu: ![Course de Cosmic Tides vers une porte lumineuse au-dessus d’une mer galactique, avec tours et vitesse.](assets/screenshots/cosmic-tides/gameplay.jpg)
 
 <a id="experimental-multiplayer"></a>
 
@@ -394,6 +620,12 @@ Mécaniques originales, compétition en ligne et expériences coopératives.
   - Plateforme: Navigateur, gratuit, sans compte. Selon le créateur, un VPN/proxy peut être nécessaire. Démarrage solo vérifié ; multijoueur non testé.
   - GPT-6 Astra: [Issue #52](https://github.com/MartinDelophy/awesome-gpt-6-astra/issues/52) — Selon le créateur : Première version avec GPT-6 Astra Pro, améliorations avec GPT-6 Astra dans Codex.
   - Aperçu: ![泡泡坦克大作战联机版 / Toon Tank Arena](https://github.com/user-attachments/assets/713d44f3-a77c-452c-ba6d-1231882dc670)
+
+- **[Above the Rooftops](https://app.usecrayon.ai/play/d09bb865-2259-42e2-86cc-fb609a9d6f28)** — Peignez un cerf-volant et volez au-dessus des toits en gérant la tension du fil, en vol libre ou dans un défi chronométré de lumières célestes.
+  - Créateur: [Tushar / @TusharXo](https://x.com/TusharXo)
+  - Plateforme: Navigateur ; choisissez un personnage, entrez sur le toit et sélectionnez Fly. Gratuit, sans compte.
+  - GPT-6 Astra: [X](https://x.com/TusharXo/status/2098156783181467801) — Tushar crédite explicitement GPT-6 Astra et Crayon pour ce jeu Three.js et cite Images 2.5 pour les visuels. [Notes de vérification](assets/screenshots/above-the-rooftops/SOURCE.md).
+  - Aperçu: ![Défi de cerf-volant au-dessus de la ville, avec altitude, tension du fil, progression des lumières et direction.](assets/screenshots/above-the-rooftops/gameplay.jpg)
 
 ## Ce que contient une fiche
 

--- a/README.hi.md
+++ b/README.hi.md
@@ -4,7 +4,7 @@
 
 # Awesome GPT-6 Astra
 
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](CONTRIBUTING.md) [![LINUX DO](https://img.shields.io/badge/LINUX%20DO-Community-f0b73f?style=flat-square)](https://linux.do/) [![Cases: 49](https://img.shields.io/badge/Cases-49-58a6ff?style=flat-square)](https://astragames.aigccreative.com/)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](CONTRIBUTING.md) [![LINUX DO](https://img.shields.io/badge/LINUX%20DO-Community-f0b73f?style=flat-square)](https://linux.do/) [![Cases: 86](https://img.shields.io/badge/Cases-86-58a6ff?style=flat-square)](https://astragames.aigccreative.com/)
 
 **GPT-6 Astra से बनाए गए दिलचस्प गेमों का संग्रह।**
 
@@ -22,7 +22,7 @@
 
 ## यहाँ से शुरू करें
 
-यहाँ **49 खेल और इंटरैक्टिव परियोजनाएँ** शामिल हैं: तीन राज्यों की क्षेत्रीय रणनीति, एक-दूसरे में फँसे लकड़ी के टुकड़ों और खिसकने वाले ब्लॉकों की पहेलियाँ, मुलायम फलों को मिलाना, एक बटन से उड़ान, जादुई कालीन पर लड़ाई, बिजली के नेटवर्क से द्वीप की रक्षा, जंगल में जीवित रहना, पानी के नीचे मछली पकड़ना, सुशी रेस्तराँ चलाना और द्वीप पर खेती करना, Bay Circuit पर कार्ट रेसिंग, पेलिकन के साथ तट पर साइकिल चलाना, टेबलटॉप खिलौनों के 3D रूपांतरण और Orbital Garden। किसी शीर्षक पर क्लिक करके सीधे ब्राउज़र में गेम खेलें।
+यहाँ **86 खेल और इंटरैक्टिव परियोजनाएँ** शामिल हैं: तीन राज्यों की क्षेत्रीय रणनीति, एक-दूसरे में फँसे लकड़ी के टुकड़ों और खिसकने वाले ब्लॉकों की पहेलियाँ, मुलायम फलों को मिलाना, प्रक्रियात्मक शहर निर्माण वाला 2048, एक बटन से उड़ान, जादुई कालीन पर लड़ाई, पाँच स्तरों वाला बुलेट-हेल शूटर, बिजली के नेटवर्क से द्वीप की रक्षा, जंगल में जीवित रहना, पानी के नीचे मछली पकड़ना, सुशी रेस्तराँ चलाना और द्वीप पर खेती करना, Bay Circuit पर कार्ट रेसिंग, पेलिकन के साथ तट पर साइकिल चलाना, टेबलटॉप खिलौनों के 3D रूपांतरण, 3D घर की सजावट और Orbital Garden। किसी शीर्षक पर क्लिक करके सीधे ब्राउज़र में गेम खेलें।
 
 सूची अपडेट: **2026-09-12**। मॉडल के उपयोग की जानकारी रचनाकारों या प्रस्तुतकर्ताओं के कथनों पर आधारित है; अपुष्ट विवरण संबंधित प्रविष्टियों में चिह्नित हैं। यह तारीख सूची के रखरखाव की है, सभी गेमों के दोबारा परीक्षण की नहीं।
 
@@ -110,6 +110,70 @@
   - GPT-6 Astra: [X](https://x.com/jumperz/status/2096600055301984738) — लेखक ने इस परियोजना के विकास में Astra के उपयोग की जानकारी दी है। [जाँच विवरण (अंग्रेज़ी)](assets/screenshots/cinderfall/SOURCE.md).
   - पूर्वावलोकन: ![Cinderfall · Fire, Shadow & Steel](assets/screenshots/cinderfall/gameplay.jpg)
 
+- **[Oz Breakdance](https://satriodewantono.com/breakdance/)** — ढीले जोड़ों वाले रैगडॉल नर्तक के हाथ-पैर खींचकर सही लक्ष्यों तक पहुँचाएँ, अंक पाएँ और समय-सीमित ब्रेकडांस राउंड को लंबा करें।
+  - निर्माता: [Satrio](https://x.com/satrio_d)
+  - प्लैटफ़ॉर्म: डेस्कटॉप ब्राउज़र, माउस नियंत्रण; बिना साइन इन किए समय-सीमित राउंड शुरू हुआ।
+  - GPT-6 Astra: [X](https://x.com/satrio_d/status/2096022866097758500) — निर्माता के अनुसार Astra ने उनके पहले से बने ब्रेकडांस गेम और उसकी प्रस्तुति को बेहतर किया। [सत्यापन टिप्पणियाँ](assets/screenshots/breakdance/SOURCE.md).
+  - पूर्वावलोकन: ![समय-सीमित ब्रेकडांस अखाड़े में पैर के लक्ष्य तक पहुँचने की कोशिश करता रैगडॉल नर्तक।](assets/screenshots/breakdance/gameplay.jpg)
+
+- **[Astral War](https://astralwar.io/)** — द्वितीय विश्व युद्ध की थीम वाला ब्राउज़र FPS, जिसमें सैनिक और ज़ॉम्बी के रूप, हथियारों के लोडआउट, बॉट प्रशिक्षण और लॉबी विकल्प हैं।
+  - निर्माता: [Rishi](https://x.com/0xRishi)
+  - प्लैटफ़ॉर्म: डेस्कटॉप ब्राउज़र, कीबोर्ड और माउस; बिना साइन इन किए बॉट प्रशिक्षण शुरू हुआ। मल्टीप्लेयर और कंट्रोलर समर्थन का परीक्षण नहीं किया गया।
+  - GPT-6 Astra: [X](https://x.com/0xRishi/status/2096079660605997264) — Rishi के अनुसार Astral War को Astra, Three.js, Meshy और ElevenLabs से बनाया गया। मौजूदा साइट में Vesper का भी श्रेय है; योगदान संबंधी टिप्पणी देखें। [सत्यापन टिप्पणियाँ](assets/screenshots/astral-war/SOURCE.md).
+  - पूर्वावलोकन: ![Astral War में चल रही लड़ाई का दृश्य, हथियार और युद्धक्षेत्र के नियंत्रण।](assets/screenshots/astral-war/gameplay.jpg)
+
+- **[FLOP CLUB](https://bubucn.com/ai-model-evals/flop-club/game/index.html)** — तीन ऊँचाइयों वाले मंचों से गोता लगाएँ, कलाबाज़ियाँ और घुमाव करें, और पानी में तैरते छल्ले को निशाना बनाकर उतरने का स्कोर बढ़ाएँ।
+  - निर्माता: [BubuAi](https://x.com/BubuStd)
+  - प्लैटफ़ॉर्म: ब्राउज़र; गेम का स्वतंत्र पेज बिना साइन इन या डाउनलोड के सीधे शुरू होता है। 2026-09-09 की जाँच में गोता शुरू किया गया; कीबोर्ड और दस्तावेज़ों में बताए गए टच नियंत्रण उपलब्ध हैं।
+  - GPT-6 Astra: [X](https://x.com/BubuStd/status/2096402783805354091) — निर्माता के अनुसार यह Three.js का इस्तेमाल करके Astra Pro को एक ही प्रॉम्प्ट देकर बनाया गया था। [सत्यापन टिप्पणियाँ](assets/screenshots/flop-club/SOURCE.md).
+  - संसाधन: [प्रोजेक्ट परिचय](https://bubucn.com/zh/ai-model-evals/flop-club)
+  - पूर्वावलोकन: ![लक्ष्य वाले छल्ले के ऊपर ऊँचे मंच पर खड़ा गोताखोर और पानी में उतरने के नियंत्रण।](assets/screenshots/flop-club/gameplay.jpg)
+
+- **[Vector Dive — Beyond the Signal](https://vector-dive.openai.chatgpt.site/)** — हर चक्कर के साथ तेज़ होते नियोन वायरफ़्रेम रास्तों पर उड़ान भरें और बूस्ट व फ़ेज़ मूव का समय साधकर अधिक देर तक टिके रहें।
+  - निर्माता: [Thomas Ricouard](https://x.com/Dimillian)
+  - प्लैटफ़ॉर्म: डेस्कटॉप ब्राउज़र; बिना साइन इन किए स्कोर वाली उड़ान शुरू हुई। WASD से उड़ान, Space से बूस्ट और Shift से फ़ेज़ मूव।
+  - GPT-6 Astra: [X](https://x.com/Dimillian/status/2097188900888322323) — निर्माता के अनुसार Astra ने नियोन/सिंथवेव शैली के दृश्य निर्देश और कॉन्सेप्ट आर्ट से गेम और संगीत बनाया। [सत्यापन टिप्पणियाँ](assets/screenshots/vector-dive/SOURCE.md).
+  - पूर्वावलोकन: ![खिलाड़ी के यान और गेम HUD के साथ Vector Dive का नियोन उड़ान मार्ग।](assets/screenshots/vector-dive/gameplay.jpg)
+
+- **[Harbor Skirmish](https://gpt6astra-game.vercel.app/)** — तीन हथियारों, छतों वाले रास्तों, डैश और ग्रैपल हुक से समुद्रतटीय कस्बे को उत्पाती खरगोशों की लहरों से बचाएँ।
+  - निर्माता: [OpenDesign](https://x.com/OpenDesignHQ)
+  - प्लैटफ़ॉर्म: डेस्कटॉप ब्राउज़र; कीबोर्ड और माउस, बिना लॉगिन या डाउनलोड के।
+  - GPT-6 Astra: [निर्माता का वक्तव्य](https://x.com/OpenDesignHQ/status/2097635757917983223) — OpenDesign ने दो मॉडलों की तुलना में इस Three.js गेम को GPT-6 Astra से बना संस्करण बताया है। [सत्यापन टिप्पणियाँ](assets/screenshots/harbor-skirmish/SOURCE.md).
+  - पूर्वावलोकन: ![Seabreeze कस्बे का प्रथम-व्यक्ति राइफ़ल दृश्य, पास आते खरगोश, लहरों का काउंटर और हथियार नियंत्रण।](assets/screenshots/harbor-skirmish/gameplay.jpg)
+
+- **[UNDERGROUND — Underground Boxing](https://iamsonic.net/2026/mini-games/underground-boxing.html)** — भूमिगत 3D रिंग में तीन समय-सीमित बॉक्सिंग राउंड खेलें और मुक्कों, बचाव, चकमा देने तथा स्टैमिना के बीच संतुलन रखें।
+  - निर्माता: [Sonic的奇思妙想](https://x.com/sonic0828)
+  - प्लैटफ़ॉर्म: डेस्कटॉप ब्राउज़र; WASD से चलें, J/K से मुक्के मारें, L से बचाव और Space से चकमा दें; लॉगिन या डाउनलोड नहीं चाहिए।
+  - GPT-6 Astra: [निर्माता का वक्तव्य](https://x.com/sonic0828/status/2097601232877781344) — निर्माता ने अपनी गेम प्रदर्शन पोस्ट शृंखला में इन मिनी-गेमों को बनाने के लिए GPT-6 Astra का नाम दिया है; बॉक्सिंग वाला जवाब इसी संस्करण का लिंक देता है। [सत्यापन टिप्पणियाँ](assets/screenshots/underground-boxing/SOURCE.md).
+  - संसाधन: [निर्माता का रिलीज़ लिंक](https://x.com/sonic0828/status/2097601584410796401)
+  - पूर्वावलोकन: ![रोशन भूमिगत रिंग में मुक्के लड़ाते दो बॉक्सर, राउंड टाइमर, स्वास्थ्य पट्टियाँ और स्टैमिना।](assets/screenshots/underground-boxing/gameplay.jpg)
+
+- **[Urban Champion 3D](https://iamsonic.net/2026/mini-games/urban-champion.html)** — सूर्यास्त के समय सड़क पर ऊँचे और नीचे मुक्के चलाएँ, जवाबी वार रोकें और गिरते गमलों से बचते हुए प्रतिद्वंद्वी को मैनहोल में धकेलें।
+  - निर्माता: [Sonic的奇思妙想](https://x.com/sonic0828)
+  - प्लैटफ़ॉर्म: डेस्कटॉप ब्राउज़र; A/D से चलें, J/K से मुक्के, U/I से बचाव और Space से चकमा; लॉगिन नहीं चाहिए।
+  - GPT-6 Astra: [निर्माता का वक्तव्य](https://x.com/sonic0828/status/2097601232877781344) — निर्माता की GPT-6 Astra गेम प्रदर्शनी में इस सड़क की लड़ाई वाले गेम के लिंक के साथ अलग रिलीज़ जवाब शामिल है। [सत्यापन टिप्पणियाँ](assets/screenshots/urban-champion-3d/SOURCE.md).
+  - संसाधन: [निर्माता का रिलीज़ लिंक](https://x.com/sonic0828/status/2097601861658587376)
+  - पूर्वावलोकन: ![Sunset Mart के सामने लड़ते नीले और लाल पात्र, राउंड टाइमर और स्टैमिना पट्टियाँ।](assets/screenshots/urban-champion-3d/gameplay.jpg)
+
+- **[Zero District — Shells 3D](https://iamsonic.net/2026/mini-games/shells-3d/play.html)** — स्वचालित गोलीबारी, चलकर चकमा देने, अनुभव बटोरने और अपग्रेड चुनने के साथ शहर की तीन मिनट की घेराबंदी में जीवित रहें।
+  - निर्माता: [Sonic的奇思妙想](https://x.com/sonic0828)
+  - प्लैटफ़ॉर्म: ब्राउज़र; WASD या खींचकर चलने का नियंत्रण, स्वचालित निशाना; लॉगिन या डाउनलोड नहीं चाहिए।
+  - GPT-6 Astra: [निर्माता का वक्तव्य](https://x.com/sonic0828/status/2097601232877781344) — निर्माता ने संग्रह की घोषणा में GPT-6 Astra का नाम दिया और अलग जवाब में इस 3D सर्वाइवल संस्करण का लिंक साझा किया। [सत्यापन टिप्पणियाँ](assets/screenshots/zero-district-shells-3d/SOURCE.md).
+  - संसाधन: [निर्माता का रिलीज़ लिंक](https://x.com/sonic0828/status/2097602391122264310)
+  - पूर्वावलोकन: ![शहर की सड़क पर घिरे दुश्मनों पर अपने-आप गोली चलाता पात्र, 14 पराजित दुश्मन और 166 सेकंड शेष।](assets/screenshots/zero-district-shells-3d/gameplay.jpg)
+
+- **[ASCII DISTRICT](https://ascii-district.vercel.app/)** — ASCII अक्षरों से बने प्रथम-व्यक्ति अखाड़े में दौड़ने, कूदने और फिसलने का इस्तेमाल कर कंप्यूटर वायरस दुश्मनों की लहरों से लड़ें।
+  - निर्माता: [Acker Code](https://x.com/acker_code)
+  - प्लैटफ़ॉर्म: डेस्कटॉप ब्राउज़र; कीबोर्ड और माउस, बिना लॉगिन के। माउस लॉक करने के लिए अखाड़े पर क्लिक करें; Esc से छोड़ें।
+  - GPT-6 Astra: [निर्माता का वक्तव्य](https://x.com/acker_code/status/2097542957070975286) — निर्माता ने इस ASCII कला वाले शूटर को बनाने के लिए स्पष्ट रूप से Codex और GPT-6 Astra को श्रेय दिया है। [सत्यापन टिप्पणियाँ](assets/screenshots/ascii-district/SOURCE.md).
+  - पूर्वावलोकन: ![पास आते वायरस दुश्मनों वाला ASCII आँगन, और गोली चलाने के बाद 29 कारतूस दिखाता राइफ़ल HUD।](assets/screenshots/ascii-district/gameplay.jpg)
+
+- **[Aura Farming: Unbothered](https://www.aigameshare.com/games/aura-farming-game)** — ड्रैगन बोट पर नाचते कैपीबारा का संतुलन बनाएँ, लहरों के विरुद्ध झुकें और 40 सेकंड का टाइमर समाप्त होने से पहले छह चालें पूरी करें।
+  - निर्माता: [nilni / @nil](https://www.aigameshare.com/profile/nil)
+  - प्लैटफ़ॉर्म: डेस्कटॉप ब्राउज़र; बिना साइन इन किए मुफ़्त खेलें। Play क्लिक करें; खाते की सुविधाएँ वैकल्पिक हैं।
+  - GPT-6 Astra: [निर्माता का गेम पेज](https://www.aigameshare.com/games/aura-farming-game) — निर्माता ने गेम के लिए GPT-6 Astra और Codex के साथ Blender, Three.js, ImageGen और WebAudio को श्रेय दिया है। [सत्यापन टिप्पणियाँ](assets/screenshots/aura-farming/SOURCE.md).
+  - पूर्वावलोकन: ![ड्रैगन बोट पर नाचता कैपीबारा, झुकने और टिके रहने के नियंत्रण, तथा छह चालों की चुनौती का HUD।](assets/screenshots/aura-farming/gameplay.jpg)
+
 <a id="puzzles"></a>
 
 ### पहेलियाँ और दिमागी खेल
@@ -135,6 +199,25 @@
   - मॉडल की भागीदारी: [निर्माण का रिकॉर्ड](works/sunjing-puzzles/CREATION.md) — Codex में गेम डिज़ाइन, प्रक्रियात्मक 3D ग्राफ़िक्स, नियम, पहेली हल करने की प्रणाली और परीक्षणों पर कई चरणों में काम किया गया। GPT-6 Astra के सटीक उपयोग की पुष्टि रचनाकार से होनी बाकी है (प्रारूप के रूप में प्रस्तुति)।
   - विकास संसाधन: [स्रोत कोड और चलाने के निर्देश](works/sunjing-puzzles/README.md) · [आवश्यकताएँ](works/sunjing-puzzles/PROMPTS.md) · तकनीक: React, Vinext/Vite, Three.js.
   - पूर्वावलोकन: ![हरे 3D कार्यमेज पर Sunjing की छह टुकड़ों वाली लकड़ी की पहेली, टुकड़ों के नंबर और उन्हें निकालने के नियंत्रण।](assets/screenshots/sunjing-puzzles/gameplay.jpg)
+
+- **[CityMaker](https://citymaker.0to1app.com)** — 4×4 शहरी ब्लॉक पर खेला जाने वाला 2048 पज़ल: एक जैसे भवन जोड़कर हर शहर में पारंपरिक घरों से पहचानी जाने वाली स्काईलाइन तक ग्यारह वास्तु स्तर चढ़ें। बारह शहर उपलब्ध हैं और दृश्य को हर बार 45° घुमाया जा सकता है।
+  - निर्माता: [Derek Wang](https://github.com/derek-wangpch)
+  - प्लैटफ़ॉर्म: WebGL वाले डेस्कटॉप और मोबाइल ब्राउज़र; अंग्रेज़ी, सरलीकृत चीनी और पारंपरिक चीनी। मुफ़्त, बिना लॉगिन या API कुंजी के; हर शहर की प्रगति मौजूदा ब्राउज़र में सहेजी जाती है। iOS की होम स्क्रीन पर इंस्टॉल किया जा सकता है।
+  - GPT-6 Astra: [निर्माण का विवरण](https://github.com/derek-wangpch/OpenCityMaker/blob/master/docs/CREATION.md) — निर्माता के अनुसार सभी 132 भवन मॉडलों की प्रक्रियात्मक ज्यामिति GPT-6 Astra से बनाई गई। संदर्भों पर आधारित प्रक्रिया में कई कोणों से अध्ययन, पहले बाहरी आकृति के अनुसार भवन के आयतन बनाना और स्क्रीनशॉट से सत्यापन शामिल था; यह एक ही प्रॉम्प्ट वाला परीक्षण नहीं था।
+  - संसाधन: [स्रोत कोड और सेटअप](https://github.com/derek-wangpch/OpenCityMaker) · [सत्यापन टिप्पणियाँ](https://github.com/derek-wangpch/OpenCityMaker/blob/master/QA.md) · इस्तेमाल की गई तकनीकें: React, TypeScript, Vite और Three.js; सभी 132 भवन मॉडल मौलिक प्रक्रियात्मक ज्यामिति से बने हैं।
+  - पूर्वावलोकन: ![CityMaker का हांगकांग बोर्ड: 4×4 ग्रिड पर कम-पॉलीगॉन वाले 3D भवन, स्कोर, शहर चुनने की पट्टी और घुमाने के नियंत्रण।](assets/screenshots/citymaker/gameplay.png)
+
+- **[Bonkshot](https://bonkshot.com/)** — गुलेल पीछे खींचें और छोटे Bonker को लकड़ी के सहारों पर छोड़कर ढाँचे गिराएँ और लक्ष्य हटाएँ।
+  - निर्माता: [edmund5](https://x.com/edmund5)
+  - प्लैटफ़ॉर्म: ब्राउज़र; निशाना लगाने के लिए खींचें और छोड़कर दागें। बिना साइन इन किए खेल सकते हैं; Google साइन इन वैकल्पिक है।
+  - GPT-6 Astra: [निर्माता का वक्तव्य](https://x.com/edmund5/status/2097603093819261002) — निर्माता ने गेम के लिए GPT-6 Astra और Three.js को श्रेय दिया है, जबकि पृष्ठभूमि संगीत Suno से बनाया गया। [सत्यापन टिप्पणियाँ](assets/screenshots/bonkshot/SOURCE.md).
+  - पूर्वावलोकन: ![पहले Grasslands पज़ल में प्रक्षेपण के बाद आंशिक रूप से गिरा लकड़ी का टावर, एक बचा लक्ष्य और 2,200 अंक।](assets/screenshots/bonkshot/gameplay.jpg)
+
+- **[Greenhouse Escape Room: The Last Seed](https://www.aigameshare.com/games/greenhouse-escape-room)** — बंद ग्रीनहाउस का अन्वेषण करें, ताँबे की पानी की पाइपें ठीक करें, पौधों और परावर्तित प्रकाश को व्यवस्थित करें और उसका अंतिम बीज बचाएँ।
+  - निर्माता: [nilni / @nil](https://www.aigameshare.com/profile/nil)
+  - प्लैटफ़ॉर्म: ब्राउज़र; Play, फिर Begin क्लिक करें। मुफ़्त, बिना साइन इन के; अंग्रेज़ी और चीनी में नियंत्रण।
+  - GPT-6 Astra: [निर्माता का गेम पेज](https://www.aigameshare.com/games/greenhouse-escape-room) — निर्माता ने GPT-6 Astra और Codex को विकास के उपकरण बताया है, साथ में ImageGen और WebAudio भी हैं। [सत्यापन टिप्पणियाँ](assets/screenshots/greenhouse-escape-room/SOURCE.md).
+  - पूर्वावलोकन: ![ग्रीनहाउस एस्केप गेम का Waterworks कमरा, नौ टाइलों वाला पाइप उपकरण, टाइमर और इन्वेंटरी।](assets/screenshots/greenhouse-escape-room/gameplay.jpg)
 
 <a id="strategy-simulation"></a>
 
@@ -227,6 +310,24 @@
   - संसाधन: [GitHub](https://github.com/LucasMarquesShiva/the-free-game)
   - पूर्वावलोकन: ![The Free Game](assets/screenshots/the-free-game/gameplay.jpg)
 
+- **[AGI of Empires — The Compute Wars](https://agiofempires.com/)** — फ़ंडिंग और GPU जुटाएँ, डेटा सेंटर और सेनाएँ बनाएँ, और प्रतिद्वंद्वी AI प्रयोगशालाओं से पहले ASI तक पहुँचें या उनके मुख्यालय नष्ट करें।
+  - निर्माता: [timour kosters](https://x.com/timourxyz)
+  - प्लैटफ़ॉर्म: डेस्कटॉप ब्राउज़र; मुफ़्त व्यंग्यात्मक रीयल-टाइम रणनीति गेम। कंप्यूटर के विरुद्ध शुरुआती मैच और संसाधन संग्रह को बिना साइन इन किए सत्यापित किया गया।
+  - GPT-6 Astra: [X](https://x.com/timourxyz/status/2096662786692776293) — निर्माता के अनुसार उन्होंने Age of Empires से प्रेरित यह गेम Astra के साथ दो दिनों में विकसित किया। [सत्यापन टिप्पणियाँ](assets/screenshots/agi-of-empires/SOURCE.md).
+  - पूर्वावलोकन: ![AGI of Empires का युद्धक्षेत्र, संसाधन काउंटर और मुख्यालय।](assets/screenshots/agi-of-empires/gameplay.jpg)
+
+- **[Atlas Go](https://atlas-go.borisxp.chatgpt.site/)** — सड़कों के नेटवर्क और अनोखे ग्राफ़ बोर्ड पर गो खेलें; एक ही डिवाइस पर बारी-बारी खेलने और दोस्तों के साथ मैच के विकल्प हैं।
+  - निर्माता: [Boris Power](https://x.com/BorisMPower)
+  - प्लैटफ़ॉर्म: ब्राउज़र; स्थानीय बोर्ड बिना साइन इन किए खुला। दोस्तों के साथ ऑनलाइन मैच का परीक्षण नहीं किया गया।
+  - GPT-6 Astra: [X](https://x.com/BorisMPower/status/2096784808399843582) — निर्माता के अनुसार मनमाने ग्राफ़ पर चलने वाला यह मल्टीप्लेयर गो गेम Astra को एक ही प्रॉम्प्ट देकर बनाया गया। [सत्यापन टिप्पणियाँ](assets/screenshots/atlas-go/SOURCE.md).
+  - पूर्वावलोकन: ![Atlas Go के मधुमक्खी के छत्ते जैसे ग्राफ़ बोर्ड पर काले और सफ़ेद मोहरे।](assets/screenshots/atlas-go/gameplay.jpg)
+
+- **[Ironwood — The Art of Industry](https://ironwood.sparkles.dev/)** — कच्चा माल इकट्ठा करें, मशीनों को बिजली दें और कन्वेयर बेल्ट जोड़कर खुली जगह को चलती हुई फ़ैक्टरी में बदलें।
+  - निर्माता: [Dan](https://x.com/aidaniil)
+  - प्लैटफ़ॉर्म: डेस्कटॉप ब्राउज़र; अतिथि ट्यूटोरियल बिना साइन इन के खुलता है, लेकिन प्रगति सहेजने के लिए लॉगिन ज़रूरी है। मल्टीप्लेयर का स्वतंत्र परीक्षण नहीं किया गया।
+  - GPT-6 Astra: [X](https://x.com/aidaniil/status/2096426970930106530) — निर्माता के अनुसार उन्होंने अपने भाई के साथ Satisfactory और Besiege से प्रेरणा लेकर Astra, Blender MCP और Cloudflare Durable Objects से इसे बनाया। [सत्यापन टिप्पणियाँ](assets/screenshots/ironwood/SOURCE.md).
+  - पूर्वावलोकन: ![Ironwood की फ़ैक्टरी मशीनें, कन्वेयर बेल्ट और संसाधन प्रबंधन का ट्यूटोरियल।](assets/screenshots/ironwood/gameplay.jpg)
+
 - **[DUST FRONT](https://dust-front.mustafaakin.dev/)** — एकल-खिलाड़ी RTS में बेस बनाएँ, ठिकानों पर कब्ज़ा करें और ज़मीनी व हवाई सेना को निर्देश दें।
   - निर्माता: [Mustafa Akın](https://x.com/mustafaakin)
   - प्लेटफ़ॉर्म: डेस्कटॉप ब्राउज़र; कीबोर्ड और माउस, लॉगिन आवश्यक नहीं।
@@ -239,6 +340,18 @@
   - GPT-6 Astra: [X](https://x.com/HDLhN783wtLkpPR/status/2097321360641122393) — लिंक की गई पोस्ट में रचनाकार ने इस RTS को बनाने का श्रेय “GPT Astra” को दिया है; मॉडल का सटीक संस्करण और विकास की विस्तृत प्रक्रिया नहीं बताई गई है।
   - संदर्भ: [प्रस्तुति](https://github.com/MartinDelophy/awesome-gpt-6-astra/issues/66) · [सत्यापन के नोट्स (अंग्रेज़ी)](assets/screenshots/frontline-command/SOURCE.md)
   - पूर्वावलोकन: ![Frontline Command के चल रहे मैच में बेस, तीन चुने हुए टैंक और बिजलीघर रखने की क्रिया; v0.8, 2026-09-09 को लिया गया।](assets/screenshots/frontline-command/gameplay.jpg)
+
+- **[Coin Pusher Roguelite: Mintfall](https://www.aigameshare.com/games/coin-pusher-roguelite-mintfall)** — 3D कॉइन पुशर में निशाना लगाएँ, विशेष सिक्कों और अवशेषों का मेल बनाएँ, और सीमित सिक्के डालने के मौकों में लक्ष्य स्कोर पाकर छह राउंड पार करें।
+  - निर्माता: [nilni / @nil](https://www.aigameshare.com/profile/nil)
+  - प्लैटफ़ॉर्म: ब्राउज़र; Play क्लिक करें, मुफ़्त और बिना साइन इन के। खाते से सेव करने का विकल्प उपलब्ध है।
+  - GPT-6 Astra: [निर्माता का गेम पेज](https://www.aigameshare.com/games/coin-pusher-roguelite-mintfall) — निर्माता ने GPT-6 Astra के साथ GPT-5.6 Sol और Codex को श्रेय दिया है; गेम पेज उनके अलग-अलग योगदान स्पष्ट नहीं करता। [सत्यापन टिप्पणियाँ](assets/screenshots/mintfall/SOURCE.md).
+  - पूर्वावलोकन: ![Mintfall के पहले राउंड की 3D सिक्का ट्रे, 33 अंक, 44 बार सिक्के डालने का संकेत और विशेष सिक्कों के नियंत्रण।](assets/screenshots/mintfall/gameplay.jpg)
+
+- **[Westward — The Oregon Trail](https://biswaz.me/westward/)** — वैगन दल को पश्चिम की ओर ले जाएँ, भोजन का राशन बाँटें, मरम्मत और शिकार सँभालें, और Oregon Trail पर निर्णय लें।
+  - निर्माता: [Biswas](https://x.com/bis_waz)
+  - प्लैटफ़ॉर्म: डेस्कटॉप ब्राउज़र; दिए गए काल्पनिक दल से शुरू करें, बिना साइन इन या इंस्टॉलेशन के।
+  - GPT-6 Astra: [X](https://x.com/bis_waz/status/2098023593468907747) — Biswas के अनुसार उन्होंने GPT-6 Astra से The Oregon Trail का यह आधुनिक 3D संस्करण बनाया और खेलने योग्य गेम का लिंक दिया है। [सत्यापन टिप्पणियाँ](assets/screenshots/westward/SOURCE.md).
+  - पूर्वावलोकन: ![Kansas River की ओर जाते वैगन और बैल, तय की गई दूरी 25 मील और अभियान की आपूर्ति वाला पैनल।](assets/screenshots/westward/gameplay.jpg)
 
 <a id="rpg-adventures"></a>
 
@@ -276,6 +389,63 @@
   - प्लेटफ़ॉर्म: डेस्कटॉप ब्राउज़र; बिना लॉगिन या भुगतान के खोला गया। मोबाइल परीक्षण नहीं हुआ।
   - GPT-6 Astra: [X](https://x.com/emollick/status/2096047660662722620) — लेखक ने इस परियोजना के विकास में Astra के उपयोग की जानकारी दी है। [जाँच विवरण (अंग्रेज़ी)](assets/screenshots/zork/SOURCE.md).
   - पूर्वावलोकन: ![Zork · The Great Underground Empire](assets/screenshots/zork/gameplay.jpg)
+
+- **[The Simpsons: Hit & Run — Browser Recreation](https://vheissu.github.io/hit-and-run-web/)** — मिशन, ट्रैफ़िक और पुलिस की पीछा-दौड़ वाले इस अनौपचारिक ब्राउज़र पुनर्निर्माण में पैदल और कार से Springfield घूमें।
+  - निर्माता: [Dwayne](https://x.com/CtrlAltDwayne)
+  - प्लैटफ़ॉर्म: डेस्कटॉप ब्राउज़र; शुरुआती बड़े एसेट डाउनलोड के बाद पहला मिशन बिना साइन इन किए लोड हुआ। पूरे अभियान को पूरा करने का परीक्षण नहीं किया गया।
+  - GPT-6 Astra: [X](https://x.com/CtrlAltDwayne/status/2096872309936287887) — निर्माता ने GPT-6 Astra से गेम को वेब के लिए दोबारा बनाने का विवरण दिया है; रिपॉज़िटरी में लोडिंग के लिए Claude की सहायता का भी श्रेय है। मूल गेम एसेट के अधिकार उनके अधिकारधारकों के पास रहते हैं। [सत्यापन टिप्पणियाँ](assets/screenshots/hit-and-run-web/SOURCE.md).
+  - संसाधन: [स्रोत कोड और सेटअप](https://github.com/Vheissu/hit-and-run-web)
+  - पूर्वावलोकन: ![Springfield में Homer, पहले मिशन का उद्देश्य और मिनीमैप दिखाई देते हुए।](assets/screenshots/hit-and-run-web/gameplay.jpg)
+
+- **[Where the Wind Wanders](https://app.usecrayon.ai/play/a9a3c165-74b3-4ff6-9588-ad97f829ddb5)** — धूप से भरी 2.5D घाटी में रास्तों पर घूमें और शांत अन्वेषण वाले इस रोमांच में हवा के तीन पत्र इकट्ठा करें।
+  - निर्माता: [Tushar](https://x.com/TusharXo)
+  - प्लैटफ़ॉर्म: ब्राउज़र, Crayon पर होस्ट किया गया; सार्वजनिक गेम पेज और उसमें लगे प्लेयर की जाँच की गई।
+  - GPT-6 Astra: [X](https://x.com/TusharXo/status/2096037482739683574) — Tushar ने Astra से रास्ते और एसेट बनाने का विवरण दिया है; बाद की पोस्ट Astra, Three.js और Crayon से बने खेलने योग्य संस्करण की घोषणा करती है। [सत्यापन टिप्पणियाँ](assets/screenshots/crayon-adventure/SOURCE.md).
+  - संसाधन: [निर्माता की रिलीज़ घोषणा](https://x.com/TusharXo/status/2096741535891251261)
+  - पूर्वावलोकन: ![फूलों से भरी घाटी में घूमता पात्र और हवा के पत्रों का उद्देश्य।](assets/screenshots/crayon-adventure/gameplay.jpg)
+
+- **[ALIBI — The Last Light](https://alibi-blackthorn-manor.vercel.app/)** — पॉइंट-एंड-क्लिक हत्या रहस्य में Blackthorn Manor की जाँच करें, दृश्यों को परखें और सुरागों से हत्यारे का पता लगाएँ।
+  - निर्माता: [Christos Antonopoulos](https://x.com/Christos_antono)
+  - प्लैटफ़ॉर्म: ब्राउज़र; इंटरैक्टिव हवेली का प्रवेश बिना साइन इन किए खुला। बाद में उत्पन्न होने वाले दृश्यों का पूरा परीक्षण नहीं किया गया।
+  - GPT-6 Astra: [X](https://x.com/Christos_antono/status/2096435122669297892) — निर्माता ने इस जनरेटिव जासूसी गेम के लिए GPT Astra और H3 Max दोनों को श्रेय दिया है। [सत्यापन टिप्पणियाँ](assets/screenshots/alibi-blackthorn-manor/SOURCE.md).
+  - पूर्वावलोकन: ![क्लिक करने योग्य दरवाज़े और शुरुआती जाँच के पाठ के साथ हवेली का प्रवेश।](assets/screenshots/alibi-blackthorn-manor/gameplay.jpg)
+
+- **[Skyward: The Gathering](https://edge-city-skyward-quests.vercel.app/)** — तैरते द्वीपों का अन्वेषण करें, बस्तियों के बीच कूदें और ग्लाइड करें, और निवासियों के लिए मिशन पूरे करें।
+  - निर्माता: [timour kosters](https://x.com/timourxyz)
+  - प्लैटफ़ॉर्म: डेस्कटॉप ब्राउज़र, कीबोर्ड और माउस; मिशन वाले संस्करण के पेज और नियंत्रणों की जाँच की गई।
+  - GPT-6 Astra: [X](https://x.com/timourxyz/status/2096379521926840339) — निर्माता के अनुसार Astra ने Edge City की जगहों से प्रेरित NPC और मिशन वाला खेलने योग्य 3D गेम बनाया। [सत्यापन टिप्पणियाँ](assets/screenshots/skyward-gathering/SOURCE.md).
+  - पूर्वावलोकन: ![Skyward के तैरते द्वीपों का व्यापक दृश्य, अन्वेषण और जर्नल नियंत्रण।](assets/screenshots/skyward-gathering/gameplay.jpg)
+
+- **[Anna & Leo · The Starstone Adventure](https://anna-leo-starstone.vercel.app/)** — Anna के संगीत वाले जादू और Leo की महाशक्तियों के बीच बदलकर सुरों वाले फूल जगाएँ और Wonder Garden का अन्वेषण करें।
+  - निर्माता: [Dharma Utomo](https://x.com/dharmautomo)
+  - प्लैटफ़ॉर्म: ब्राउज़र; शुरुआती मिशन बिना साइन इन किए शुरू हुआ। WASD से चलें, Space से कूदें, E से शक्ति और Tab से नायक बदलें।
+  - GPT-6 Astra: [X](https://x.com/dharmautomo/status/2096573649235091967) — निर्माता के अनुसार GPT-6 Astra ने इस 3D रोमांच को बनाने में मदद की; उन्होंने अपने बच्चों के खेलने के परीक्षण का वीडियो भी साझा किया। [सत्यापन टिप्पणियाँ](assets/screenshots/anna-leo-starstone/SOURCE.md).
+  - पूर्वावलोकन: ![Anna और Leo की 3D साहसिक दुनिया और मिशन इंटरफ़ेस।](assets/screenshots/anna-leo-starstone/gameplay.jpg)
+
+- **[The Legend of Deller](https://rain-court-js.umodeler-inc-4323.chatgpt.site/)** — Rainmist Haven घूमें और तलवार के कॉम्बो, तत्त्व-आधारित कौशल तथा बचाव की चालों के साथ कालकोठरियों की ओर बढ़ें।
+  - निर्माता: [UModeler X PicoBerry](https://x.com/UModeler)
+  - प्लैटफ़ॉर्म: डेस्कटॉप ब्राउज़र; कीबोर्ड और माउस, बिना लॉगिन के। शुरुआती 3D एसेट पूरी तरह लोड होने दें।
+  - GPT-6 Astra: [निर्माता का वक्तव्य](https://x.com/UModeler/status/2097792348407099553) — निर्माता के अनुसार PicoBerry ने एसेट बनाए और GPT-6 Astra ने उन्हें इस्तेमाल करने वाला Three.js एक्शन RPG बनाया। [सत्यापन टिप्पणियाँ](assets/screenshots/the-legend-of-deller/SOURCE.md).
+  - संसाधन: [निर्माता का रिलीज़ लिंक](https://x.com/UModeler/status/2097792351129178451)
+  - पूर्वावलोकन: ![Rainmist Haven में फव्वारे और बाज़ार की दुकानों के पास चकमा देता Deller, स्वास्थ्य, माना और कौशल नियंत्रण।](assets/screenshots/the-legend-of-deller/gameplay.jpg)
+
+- **[Dungeon of Astra](https://wavedash.com/games/dungeon-of-astra)** — दल में साथी भर्ती करें, सौ मंज़िला कालकोठरी में उतरें और स्थायी मृत्यु वाले अभियान में तलवार, आग के गोलों और साथियों की भूमिकाओं को मिलाएँ।
+  - निर्माता: [tonysuri / @tonysurix](https://x.com/tonysurix)
+  - प्लैटफ़ॉर्म: Wavedash पर डेस्कटॉप ब्राउज़र; मूल गेम बिना साइन इन किए शुरू होता है। वैकल्पिक खाते और पैसे देकर पात्रों को समय से पहले खोलने की सुविधा उपलब्ध है।
+  - GPT-6 Astra: [निर्माता का वक्तव्य](https://x.com/tonysurix/status/2097873333551616355) — निर्माता ने स्पष्ट कहा है कि यह दल के साथ कालकोठरी खोजने वाला गेम GPT-6 Astra से बनाया गया। [सत्यापन टिप्पणियाँ](assets/screenshots/dungeon-of-astra/SOURCE.md).
+  - पूर्वावलोकन: ![कालकोठरी की पहली मंज़िल पर आग के गोले का इस्तेमाल करते नायक और किराए का शूरवीर, दल का स्वास्थ्य और मिनीमैप।](assets/screenshots/dungeon-of-astra/gameplay.jpg)
+
+- **[Sunlandia — The Forgotten Shore](https://sunlandia.smallweblab.com/)** — जहाज़ डूबने के बाद एक द्वीप खोजें, प्रथम-व्यक्ति दृष्टि से सुराग जाँचें और प्रकाशस्तंभ की ओर जाते हुए परिवेश की पहेलियाँ सुलझाएँ।
+  - निर्माता: [Ramon Linares / Small Web Lab](https://github.com/RamonLinares)
+  - प्लैटफ़ॉर्म: डेस्कटॉप ब्राउज़र; द्वीप लोड होने दें, फिर Begin expedition चुनें। मुफ़्त, बिना खाते या इंस्टॉलेशन के।
+  - GPT-6 Astra: [निर्माता की विकास डायरी](https://smallweblab.com/posts/sunlandia/) — निर्माता ने GPT-5.6 Sol से शुरुआत की, Fable की मदद ली और GPT-6 Astra से गेम पूरा किया। [सत्यापन टिप्पणियाँ](assets/screenshots/sunlandia/SOURCE.md).
+  - पूर्वावलोकन: ![Sunlandia का प्रथम-व्यक्ति तट दृश्य, जहाज़ का मलबा, टूटा घाट और मदद खोजने का उद्देश्य।](assets/screenshots/sunlandia/gameplay.jpg)
+
+- **[NÁCAR](https://nacar-microcosmo.preda2005.chatgpt.site/)** — पानी से भरे घोंघे के खोल के भीतर एक सूक्ष्म जीव बढ़ाएँ, पोषक तत्व जुटाएँ और अन्वेषण के साथ शरीर के नए अंग विकसित करें।
+  - निर्माता: [Marcio Lima / @Preda2005](https://x.com/Preda2005)
+  - प्लैटफ़ॉर्म: ब्राउज़र; मुफ़्त बीटा, बिना साइन इन के; चीनी सहित पाँच इंटरफ़ेस भाषाएँ।
+  - GPT-6 Astra: [निर्माता की पोस्ट शृंखला](https://x.com/Preda2005/status/2097954217180921928) — Marcio के अनुसार उन्होंने जीव के विकास का यह विचार GPT-6 Astra को समझाया और इसे लिंक किए गए बीटा में विकसित किया। [सत्यापन टिप्पणियाँ](assets/screenshots/nacar/SOURCE.md).
+  - पूर्वावलोकन: ![रंगीन पोषक तत्वों के बीच छोटी कोशिका, बायोमास, विकास, इन्वेंटरी और खोजे गए जलक्षेत्र के नियंत्रण।](assets/screenshots/nacar/gameplay.jpg)
 
 <a id="platformers-racing"></a>
 
@@ -341,6 +511,31 @@
   - GPT-6 Astra: [Issue #51](https://github.com/MartinDelophy/awesome-gpt-6-astra/issues/51) — निर्माता के अनुसार: पहला संस्करण Qwen3.8 Max से; दूसरा Astra से पूरी तरह पुनर्निर्मित।
   - पूर्वावलोकन: ![疾风赛道 / Kart Racing（跑跑卡丁车）](https://github.com/user-attachments/assets/015e0ca1-7032-4d0e-9391-ad3f40d84227)
 
+- **[TIDAL RUSH — Paradise GP](https://tidal-rush-paradise-gp.skirano.chatgpt.site/)** — उष्णकटिबंधीय कार्ट ट्रैक पर ड्रिफ़्ट करें, आइटम इस्तेमाल करें और तीन चक्करों में सात प्रतिद्वंद्वियों से रेस करें।
+  - निर्माता: [Pietro Schirano](https://x.com/skirano)
+  - प्लैटफ़ॉर्म: ब्राउज़र; तीन चक्करों की रेस बिना साइन इन किए शुरू हुई। ड्राइविंग, ड्रिफ़्ट और आइटम के लिए कीबोर्ड नियंत्रण, साथ में स्क्रीन पर टच बटन।
+  - GPT-6 Astra: [मॉडल के उपयोग का प्रमाण](https://openai.com/index/gpt-6-astra/) — OpenAI के Astra लॉन्च पेज में इस इंटरैक्टिव कार्ट गेम का लिंक है और Pietro Schirano को श्रेय दिया गया है। X पर इसकी जानकारी देने वाली पोस्ट समुदाय की साझा पोस्ट है, निर्माता की अपनी पोस्ट नहीं। [सत्यापन टिप्पणियाँ](assets/screenshots/tidal-rush/SOURCE.md).
+  - संसाधन: [X पर गेम की जानकारी](https://x.com/alexgetmancom/status/2095598460921614825)
+  - पूर्वावलोकन: ![Tidal Rush का उष्णकटिबंधीय कार्ट ट्रैक, रेस की स्थिति और ड्रिफ़्ट नियंत्रण।](assets/screenshots/tidal-rush/gameplay.jpg)
+
+- **[LUNA — Crimson Requiem / 紅月のレクイエム](https://luna-crimson-requiem.ponsuke.chatgpt.site/)** — गॉथिक पिक्सेल आर्ट वाले स्तर में कूदें, दुश्मनों पर वार करें, ऊपर से कूदकर उन्हें कुचलें या हमला बुलाएँ—एक छोटा साइड-स्क्रॉलिंग रोमांच।
+  - निर्माता: [音羽ぽんすけ](https://x.com/ponsuke_otowa)
+  - प्लैटफ़ॉर्म: ब्राउज़र, जापानी इंटरफ़ेस; कीबोर्ड नियंत्रण और निर्माता द्वारा बताया गया स्मार्टफ़ोन समर्थन। एक स्तर उपलब्ध है।
+  - GPT-6 Astra: [X](https://x.com/ponsuke_otowa/status/2096531744933425299) — निर्माता के अनुसार Astra से विकास में लगभग 25 मिनट लगे और चलने के एनीमेशन में एक सुधार किया गया; संगीत का श्रेय अलग से Suno को है। [सत्यापन टिप्पणियाँ](assets/screenshots/luna-crimson-requiem/SOURCE.md).
+  - पूर्वावलोकन: ![लाल चाँद वाली गॉथिक सड़क पर लड़ती LUNA, स्वास्थ्य और समन मीटर।](assets/screenshots/luna-crimson-requiem/gameplay.jpg)
+
+- **[Strange Orbit](https://app.usecrayon.ai/play/47df78e2-1410-45d1-833c-196e1161c0b8)** — ग्रह के छल्लों पर अंतरिक्ष यात्री साइकिल चालकों की रेस करें, तारों की धूल इकट्ठा करें, प्रतिद्वंद्वियों के पीछे चलकर हवा का प्रतिरोध घटाएँ और Orbital Cup में बूस्ट लें।
+  - निर्माता: [Crayon](https://x.com/usecrayon)
+  - प्लैटफ़ॉर्म: Crayon पर ब्राउज़र; कीबोर्ड और दस्तावेज़ों में बताए गए टच नियंत्रण। सार्वजनिक पेज में रेस, समय-परीक्षण और अंतहीन भ्रमण के मोड हैं।
+  - GPT-6 Astra: [X](https://x.com/usecrayon/status/2097468975995302167) — Crayon ने इस अंतरिक्ष साइकिल गेम के लिए GPT-6 Astra, Crayon Pro और Three.js को श्रेय दिया है। [सत्यापन टिप्पणियाँ](assets/screenshots/crayon-space-bike/SOURCE.md).
+  - पूर्वावलोकन: ![ग्रह के छल्ले पर रेस करते अंतरिक्ष यात्री साइकिल चालक, चक्कर, स्थिति और तारों की धूल के संकेतक।](assets/screenshots/crayon-space-bike/gameplay.jpg)
+
+- **[One More Vine — Into the Wild](https://onemorevine.bennash.dev/)** — जंगल के चार स्तरों में दौड़ें, कूदें और बेलों पर झूलें, खज़ाने जुटाएँ, मगरमच्छों से बचें और अपना समय सुधारें।
+  - निर्माता: [Ben Nash](https://x.com/bennash)
+  - प्लैटफ़ॉर्म: ब्राउज़र, कीबोर्ड और स्क्रीन पर गति नियंत्रण; पहला स्तर और निर्देश बिना साइन इन किए लोड हुए।
+  - GPT-6 Astra: [X](https://x.com/bennash/status/2096282758930645170) — निर्माता ने स्पष्ट रूप से इसे GPT-6 Astra से बना, Pitfall से प्रेरित चार स्तरों वाला गेम बताया है। [सत्यापन टिप्पणियाँ](assets/screenshots/one-more-vine/SOURCE.md).
+  - पूर्वावलोकन: ![लटकती बेलों, खज़ानों, गड्ढों और मगरमच्छों वाला जंगल का प्लेटफ़ॉर्म स्तर।](assets/screenshots/one-more-vine/gameplay.jpg)
+
 - **[混合马里奥Ⅱ · 忍者龙剑传 × 坦克大战 / Mario Mix II](https://aha-xiaoq.github.io/games/mario-mix-2/play.html)** — Ninja Gaiden के Ryu Hayabusa और Battle City के टैंक के साथ Mario की भूमिगत दुनिया 1-2 में जाएँ: र्यू के साथ साइड-स्क्रॉलिंग में कूदें, दीवारें चढ़ें और लड़ें, टैंक के साथ ऊपर से दिखने वाली लड़ाइयाँ खेलें, या निंजा से टैंक तक की रिले में राजकुमारी को बचाएँ।
   - रचनाकार: [在下_小Q（Aha-xiaoQ）](https://github.com/Aha-xiaoQ)
   - प्लैटफ़ॉर्म: कंप्यूटर का ब्राउज़र, चीनी इंटरफ़ेस, कीबोर्ड का उपयोग सुझाया गया है; मुफ़्त, लॉगिन या इंस्टॉलेशन की ज़रूरत नहीं।
@@ -349,6 +544,37 @@
   - अधिकार: यह अनौपचारिक फ़ैन गेम है; पुराने पात्रों, चित्रों और संगीत के अधिकार उनके संबंधित अधिकारधारकों के पास हैं। सामग्री का श्रेय मूल गेम के पृष्ठ पर दिया गया है।
   - पूर्वावलोकन: ![Mario Mix II — रचनाकार का दिया हुआ वीडियो कवर, गेमप्ले का स्क्रीनशॉट नहीं।](https://aha-xiaoq.github.io/games/mario-mix-2/cover.jpg)
   - स्क्रीनशॉट: ![Mario Mix II का टैंक दुनिया 1-2 के प्रवेश पर गोली चला रहा है; चल रहा संस्करण 1.0, 2026-09-09 को लिया गया।](assets/screenshots/mario-mix-2/gameplay.jpg)
+
+- **[Bengaluru ORR Rush](https://orr-rush-bengaluru.ravitheja.chatgpt.site/)** — बेंगलुरु के ट्रैफ़िक में रेस करें, गड्ढों और डिलीवरी बाइकों से बचें और जगह बनाने के लिए बूस्ट या बगल की ओर झटका इस्तेमाल करें।
+  - निर्माता: [Ravi Theja](https://x.com/ravithejads)
+  - प्लैटफ़ॉर्म: डेस्कटॉप ब्राउज़र; कीबोर्ड नियंत्रण और वैकल्पिक ऑटो-थ्रॉटल, बिना लॉगिन के।
+  - GPT-6 Astra: [निर्माता का वक्तव्य](https://x.com/ravithejads/status/2097181044625887392) — निर्माता ने बेंगलुरु की सड़क रेसिंग वाले इस गेम का श्रेय GPT-6 Astra को दिया है। [सत्यापन टिप्पणियाँ](assets/screenshots/bengaluru-orr-rush/SOURCE.md).
+  - पूर्वावलोकन: ![बेंगलुरु के ट्रैफ़िक में खिलाड़ी की नीली कार, रेस स्थिति, गति, टाइमर और नियंत्रण संकेत।](assets/screenshots/bengaluru-orr-rush/gameplay.jpg)
+
+- **[SKICROSS — Alpine Downhill](https://iamsonic.net/2026/mini-games/skicross.html)** — तीन स्की खिलाड़ियों के विरुद्ध पहाड़ से नीचे रेस करें, गेट और बाधाएँ पार करें, और हिमस्खलन से आगे रहें।
+  - निर्माता: [Sonic的奇思妙想](https://x.com/sonic0828)
+  - प्लैटफ़ॉर्म: डेस्कटॉप ब्राउज़र; A/D से दिशा, Space से छलाँग और Shift से बूस्ट; लॉगिन या डाउनलोड नहीं चाहिए।
+  - GPT-6 Astra: [निर्माता का वक्तव्य](https://x.com/sonic0828/status/2097601232877781344) — निर्माता ने मिनी-गेम संग्रह का श्रेय GPT-6 Astra को दिया और अलग जवाब में यह स्की गेम साझा किया। [सत्यापन टिप्पणियाँ](assets/screenshots/skicross/SOURCE.md).
+  - संसाधन: [निर्माता का रिलीज़ लिंक](https://x.com/sonic0828/status/2097601732297814300)
+  - पूर्वावलोकन: ![बर्फ़ीले ट्रैक पर चार स्की खिलाड़ी, गेट बोनस, रेस रैंकिंग, गति और हिमस्खलन की दूरी के संकेतक।](assets/screenshots/skicross/gameplay.jpg)
+
+- **[Itsy Bitsy Spider · One More Climb](https://game-bench.piccini.app/games/gpt-6-astra/)** — काई वाली दीवार चढ़ें, पकड़ की ताकत लौटाने के लिए मक्खियाँ पकड़ें और बारिश के मकड़ी को बहा देने से पहले आश्रय वाले छेदों में छिपें।
+  - निर्माता: [Luiz Piccini](https://piccini.app/)
+  - प्लैटफ़ॉर्म: ब्राउज़र; मुफ़्त, बिना साइन इन के। WASD या स्क्रीन वाला जॉयस्टिक।
+  - GPT-6 Astra: [निर्माता का Game Bench](https://game-bench.piccini.app/) — Game Bench ने इस प्रकाशित परिणाम को GPT-6 Astra canary, high, दिनांक 2026-09-05 के रूप में चिह्नित किया है; यह उसके साझा गेम निर्देशों से बना है। [सत्यापन टिप्पणियाँ](assets/screenshots/itsy-bitsy-spider/SOURCE.md).
+  - पूर्वावलोकन: ![काई वाली ईंट की दीवार पर 2 मीटर ऊँचाई पर चढ़ती मकड़ी, पकड़, मक्खियाँ, आश्रय और गति का जॉयस्टिक।](assets/screenshots/itsy-bitsy-spider/gameplay.jpg)
+
+- **[Desi Mayhem](https://desimayhem.com/)** — भारतीय शहरों के ट्रैफ़िक में मोटरसाइकिल रेस करें, बसों और ऑटो के बीच निकलें और लात, मुक्के तथा बूस्ट इस्तेमाल करें।
+  - निर्माता: [Kishore](https://x.com/GetKishore)
+  - प्लैटफ़ॉर्म: डेस्कटॉप ब्राउज़र; मुफ़्त, बिना खाते के। पहली सवारी से पहले बनाए गए राइडर उपनाम को स्वीकारें या बदलें।
+  - GPT-6 Astra: [निर्माता की विकास संबंधी पोस्ट शृंखला](https://x.com/GetKishore/status/2097906401159102811) — Kishore ने सड़क के संदर्भों और ट्रैफ़िक, टक्करों व राइडर की लड़ाई के बार-बार परीक्षण से Astra में बने 3D गेम को सुधारने का विवरण दिया है। [सत्यापन टिप्पणियाँ](assets/screenshots/desi-mayhem/SOURCE.md).
+  - पूर्वावलोकन: ![चेन्नई की मोटरसाइकिल रेस, खिलाड़ी का राइडर, शहर का ट्रैफ़िक, मिनीमैप, स्थिति और रेस टाइमर।](assets/screenshots/desi-mayhem/gameplay.jpg)
+
+- **[Cosmic Tides](https://app.usecrayon.ai/play/362ae1e7-29bd-4fbc-9103-00649265d942)** — आकाशगंगीय महासागर पर यान चलाएँ, चमकते गेटों का रास्ता पकड़ें और दो चक्करों की रेस या अंतहीन बहाव में से चुनें।
+  - निर्माता: [Aniket J](https://x.com/aniketjart)
+  - प्लैटफ़ॉर्म: ब्राउज़र; 3D एसेट लोड होने दें, फिर Ride the current चुनें। मुफ़्त, बिना साइन इन के।
+  - GPT-6 Astra: [X](https://x.com/aniketjart/status/2098207146647433534) — Aniket ने गेम के लिए GPT-6 Astra, Blender MCP और Crayon को श्रेय दिया है; उनके अनुसार यह एक प्रयोग है जिसमें गेमप्ले को आगे सुधारने की योजना है। [सत्यापन टिप्पणियाँ](assets/screenshots/cosmic-tides/SOURCE.md).
+  - पूर्वावलोकन: ![Cosmic Tides की चलती रेस, आकाशगंगीय समुद्र पर चमकते गेट की ओर बढ़ता यान, चक्कर और गति के संकेतक।](assets/screenshots/cosmic-tides/gameplay.jpg)
 
 <a id="experimental-multiplayer"></a>
 
@@ -394,6 +620,12 @@
   - प्लेटफ़ॉर्म: ब्राउज़र, मुफ़्त, बिना खाते के। निर्माता के अनुसार VPN/प्रॉक्सी आवश्यक हो सकता है। सोलो शुरुआत जाँची गई; मल्टीप्लेयर नहीं।
   - GPT-6 Astra: [Issue #52](https://github.com/MartinDelophy/awesome-gpt-6-astra/issues/52) — निर्माता के अनुसार: पहला संस्करण GPT-6 Astra Pro से; बाद के सुधार Codex में GPT-6 Astra से।
   - पूर्वावलोकन: ![泡泡坦克大作战联机版 / Toon Tank Arena](https://github.com/user-attachments/assets/713d44f3-a77c-452c-ba6d-1231882dc670)
+
+- **[Above the Rooftops](https://app.usecrayon.ai/play/d09bb865-2259-42e2-86cc-fb609a9d6f28)** — पतंग रंगें और शहर की छतों के ऊपर उड़ाएँ; स्वतंत्र उड़ान या समय-सीमित आसमानी रोशनी की चुनौती में डोर का तनाव संतुलित रखें।
+  - निर्माता: [Tushar / @TusharXo](https://x.com/TusharXo)
+  - प्लैटफ़ॉर्म: ब्राउज़र; पात्र चुनें, छत पर जाएँ और Fly चुनें। मुफ़्त, बिना साइन इन के।
+  - GPT-6 Astra: [X](https://x.com/TusharXo/status/2098156783181467801) — Tushar ने इस Three.js पतंग गेम के लिए स्पष्ट रूप से GPT-6 Astra और Crayon को श्रेय दिया है और दृश्यों के लिए Images 2.5 का उल्लेख किया है। [सत्यापन टिप्पणियाँ](assets/screenshots/above-the-rooftops/SOURCE.md).
+  - पूर्वावलोकन: ![शहर के ऊपर पतंग की चुनौती, ऊँचाई, डोर का तनाव, आसमानी रोशनी की प्रगति और दिशा नियंत्रण।](assets/screenshots/above-the-rooftops/gameplay.jpg)
 
 ## हर प्रविष्टि में क्या शामिल है
 

--- a/README.id.md
+++ b/README.id.md
@@ -4,7 +4,7 @@
 
 # Awesome GPT-6 Astra
 
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](CONTRIBUTING.md) [![LINUX DO](https://img.shields.io/badge/LINUX%20DO-Community-f0b73f?style=flat-square)](https://linux.do/) [![Cases: 49](https://img.shields.io/badge/Cases-49-58a6ff?style=flat-square)](https://astragames.aigccreative.com/)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](CONTRIBUTING.md) [![LINUX DO](https://img.shields.io/badge/LINUX%20DO-Community-f0b73f?style=flat-square)](https://linux.do/) [![Cases: 86](https://img.shields.io/badge/Cases-86-58a6ff?style=flat-square)](https://astragames.aigccreative.com/)
 
 **Kumpulan gim menarik yang dibuat dengan GPT-6 Astra.**
 
@@ -22,7 +22,7 @@ Halaman ini merupakan terjemahan [README bahasa Inggris](README.md). Periksa ver
 
 ## Mulai di sini
 
-Jelajahi **49 gim dan proyek interaktif**: strategi wilayah Tiga Kerajaan, teka-teki kayu yang saling mengunci dan teka-teki balok geser, penggabungan buah yang lentur, penerbangan satu tombol, pertempuran karpet ajaib, pertahanan pulau dengan jaringan listrik, bertahan hidup di alam liar, menangkap ikan di bawah air, mengelola restoran sushi, dan bertani di pulau, balapan kart di Bay Circuit, bersepeda di pesisir bersama pelikan, mainan meja yang diadaptasi menjadi gim 3D, serta Orbital Garden. Klik judul untuk langsung bermain di peramban.
+Jelajahi **86 gim dan proyek interaktif**: strategi wilayah Tiga Kerajaan, teka-teki kayu yang saling mengunci dan teka-teki balok geser, penggabungan buah yang lentur, 2048 pembangunan kota dengan generasi prosedural, penerbangan satu tombol, pertempuran karpet ajaib, gim tembak-menembak dengan hujan peluru dalam lima level, pertahanan pulau dengan jaringan listrik, bertahan hidup di alam liar, menangkap ikan di bawah air, mengelola restoran sushi, dan bertani di pulau, balapan kart di Bay Circuit, bersepeda di pesisir bersama pelikan, mainan meja yang diadaptasi menjadi gim 3D, dekorasi rumah 3D, serta Orbital Garden. Klik judul untuk langsung bermain di peramban.
 
 Katalog diperbarui: **2026-09-12**. Informasi penggunaan model berdasarkan pernyataan kreator atau pengirim; detail yang belum dikonfirmasi ditandai pada setiap entri. Tanggal ini menunjukkan pemeliharaan katalog, bukan pengujian ulang seluruh gim.
 
@@ -110,6 +110,70 @@ Gim tembak-menembak, pertarungan, bertahan hidup, ritme, dan apa pun yang membua
   - GPT-6 Astra: [X](https://x.com/jumperz/status/2096600055301984738) — Kreator menyatakan menggunakan Astra dalam pengembangan proyek ini. [Catatan verifikasi (Inggris)](assets/screenshots/cinderfall/SOURCE.md).
   - Pratinjau: ![Cinderfall · Fire, Shadow & Steel](assets/screenshots/cinderfall/gameplay.jpg)
 
+- **[Oz Breakdance](https://satriodewantono.com/breakdance/)** — Seret anggota tubuh penari ragdoll ke sasaran yang sesuai untuk meraih poin dan memperpanjang ronde breakdance berbatas waktu.
+  - Kreator: [Satrio](https://x.com/satrio_d)
+  - Platform: Browser desktop, kontrol mouse; ronde berbatas waktu berhasil dimulai tanpa login.
+  - GPT-6 Astra: [X](https://x.com/satrio_d/status/2096022866097758500) — Kreator menyatakan bahwa Astra menyempurnakan game breakdance yang sudah ia buat beserta tampilannya. [Catatan verifikasi](assets/screenshots/breakdance/SOURCE.md).
+  - Pratinjau: ![Penari ragdoll membidik sasaran kaki di arena breakdance dengan batas waktu.](assets/screenshots/breakdance/gameplay.jpg)
+
+- **[Astral War](https://astralwar.io/)** — FPS browser bertema Perang Dunia II dengan penampilan prajurit dan zombi, pilihan perlengkapan senjata, latihan melawan bot, dan opsi lobi.
+  - Kreator: [Rishi](https://x.com/0xRishi)
+  - Platform: Browser desktop, keyboard dan mouse; latihan bot berhasil dimulai tanpa login. Multipemain dan dukungan kontroler belum diuji.
+  - GPT-6 Astra: [X](https://x.com/0xRishi/status/2096079660605997264) — Rishi menyatakan bahwa Astral War dibuat dengan Astra, Three.js, Meshy, dan ElevenLabs. Situs saat ini juga mencantumkan Vesper; lihat catatan atribusi. [Catatan verifikasi](assets/screenshots/astral-war/SOURCE.md).
+  - Pratinjau: ![Tampilan pertempuran Astral War yang sedang berjalan, dengan senjata dan kontrol medan perang.](assets/screenshots/astral-war/gameplay.jpg)
+
+- **[FLOP CLUB](https://bubucn.com/ai-model-evals/flop-club/game/index.html)** — Terjun dari tiga ketinggian platform, lakukan salto dan putaran, lalu bidik cincin yang mengapung untuk meningkatkan skor masuk ke air.
+  - Kreator: [BubuAi](https://x.com/BubuStd)
+  - Platform: Browser; halaman game mandiri langsung berjalan tanpa login atau unduhan. Lompatan terjun berhasil dimulai pada pemeriksaan 2026-09-09; tersedia kontrol keyboard dan kontrol sentuh yang dijelaskan dalam dokumentasi.
+  - GPT-6 Astra: [X](https://x.com/BubuStd/status/2096402783805354091) — Kreator melaporkan pembuatan dengan satu prompt Astra Pro menggunakan Three.js. [Catatan verifikasi](assets/screenshots/flop-club/SOURCE.md).
+  - Referensi: [Pengenalan proyek](https://bubucn.com/zh/ai-model-evals/flop-club)
+  - Pratinjau: ![Penerjun di platform tinggi di atas cincin sasaran dan kontrol pendaratan di air.](assets/screenshots/flop-club/gameplay.jpg)
+
+- **[Vector Dive — Beyond the Signal](https://vector-dive.openai.chatgpt.site/)** — Terbang melintasi sirkuit kerangka neon yang makin cepat setiap putaran, atur waktu dorongan dan perpindahan fase untuk bertahan lebih lama.
+  - Kreator: [Thomas Ricouard](https://x.com/Dimillian)
+  - Platform: Browser desktop; penerbangan dengan perhitungan skor berhasil dimulai tanpa login. WASD untuk terbang, Space untuk dorongan, dan Shift untuk perpindahan fase.
+  - GPT-6 Astra: [X](https://x.com/Dimillian/status/2097188900888322323) — Kreator menyatakan bahwa Astra membuat game dan musiknya berdasarkan arahan visual neon/synthwave serta seni konsep. [Catatan verifikasi](assets/screenshots/vector-dive/SOURCE.md).
+  - Pratinjau: ![Lintasan terbang neon Vector Dive dengan pesawat pemain dan HUD permainan.](assets/screenshots/vector-dive/gameplay.jpg)
+
+- **[Harbor Skirmish](https://gpt6astra-game.vercel.app/)** — Lindungi kota pesisir dari gelombang kelinci liar dengan tiga senjata, rute di atas atap, gerakan melesat, dan kait penarik.
+  - Kreator: [OpenDesign](https://x.com/OpenDesignHQ)
+  - Platform: Browser desktop; keyboard dan mouse, tanpa login atau unduhan.
+  - GPT-6 Astra: [Pernyataan kreator](https://x.com/OpenDesignHQ/status/2097635757917983223) — OpenDesign menyebut game Three.js ini sebagai versi buatan GPT-6 Astra dalam perbandingan dua modelnya. [Catatan verifikasi](assets/screenshots/harbor-skirmish/SOURCE.md).
+  - Pratinjau: ![Pandangan senapan orang pertama ke kota Seabreeze, kelinci yang mendekat, penghitung gelombang, dan kontrol senjata.](assets/screenshots/harbor-skirmish/gameplay.jpg)
+
+- **[UNDERGROUND — Underground Boxing](https://iamsonic.net/2026/mini-games/underground-boxing.html)** — Bertinju selama tiga ronde berbatas waktu di ring bawah tanah 3D, sambil menyeimbangkan pukulan, tangkisan, penghindaran, dan stamina.
+  - Kreator: [Sonic的奇思妙想](https://x.com/sonic0828)
+  - Platform: Browser desktop; WASD untuk bergerak, J/K untuk memukul, L untuk menangkis, dan Space untuk menghindar; tanpa login atau unduhan.
+  - GPT-6 Astra: [Pernyataan kreator](https://x.com/sonic0828/status/2097601232877781344) — Utas pameran kreator menyebut GPT-6 Astra sebagai alat untuk menghasilkan kumpulan mini-game ini; balasan tentang tinju menautkan versi ini. [Catatan verifikasi](assets/screenshots/underground-boxing/SOURCE.md).
+  - Referensi: [Tautan rilis dari kreator](https://x.com/sonic0828/status/2097601584410796401)
+  - Pratinjau: ![Dua petinju saling memukul di ring bawah tanah yang diterangi lampu, dengan penghitung waktu ronde, bilah kesehatan, dan stamina.](assets/screenshots/underground-boxing/gameplay.jpg)
+
+- **[Urban Champion 3D](https://iamsonic.net/2026/mini-games/urban-champion.html)** — Saling melancarkan pukulan atas dan bawah di jalan saat senja, tangkis serangan balasan, dan desak lawan ke lubang saluran sambil menghindari pot bunga yang jatuh.
+  - Kreator: [Sonic的奇思妙想](https://x.com/sonic0828)
+  - Platform: Browser desktop; A/D untuk bergerak, J/K untuk memukul, U/I untuk menangkis, dan Space untuk menghindar; tanpa login.
+  - GPT-6 Astra: [Pernyataan kreator](https://x.com/sonic0828/status/2097601232877781344) — Pameran karya GPT-6 Astra dari kreator mencakup balasan rilis terpisah yang menautkan game pertarungan jalanan ini. [Catatan verifikasi](assets/screenshots/urban-champion-3d/SOURCE.md).
+  - Referensi: [Tautan rilis dari kreator](https://x.com/sonic0828/status/2097601861658587376)
+  - Pratinjau: ![Petarung biru dan merah saling memukul di depan Sunset Mart, dengan penghitung waktu ronde dan bilah stamina.](assets/screenshots/urban-champion-3d/gameplay.jpg)
+
+- **[Zero District — Shells 3D](https://iamsonic.net/2026/mini-games/shells-3d/play.html)** — Bertahan dari pengepungan kota selama tiga menit dengan tembakan otomatis, menghindar melalui gerakan, mengumpulkan pengalaman, dan memilih peningkatan.
+  - Kreator: [Sonic的奇思妙想](https://x.com/sonic0828)
+  - Platform: Browser; bergerak dengan WASD atau menyeret, bidikan otomatis; tanpa login atau unduhan.
+  - GPT-6 Astra: [Pernyataan kreator](https://x.com/sonic0828/status/2097601232877781344) — Kreator menyebut GPT-6 Astra dalam pengumuman koleksi dan menautkan versi bertahan hidup 3D ini dalam balasan tersendiri. [Catatan verifikasi](assets/screenshots/zero-district-shells-3d/SOURCE.md).
+  - Referensi: [Tautan rilis dari kreator](https://x.com/sonic0828/status/2097602391122264310)
+  - Pratinjau: ![Penyintas menembak otomatis ke arah musuh di sekelilingnya di jalan kota, dengan 14 musuh dikalahkan dan sisa waktu 166 detik.](assets/screenshots/zero-district-shells-3d/gameplay.jpg)
+
+- **[ASCII DISTRICT](https://ascii-district.vercel.app/)** — Lawan gelombang musuh virus komputer di arena orang pertama yang digambar dengan karakter ASCII, dengan kemampuan berlari cepat, melompat, dan meluncur.
+  - Kreator: [Acker Code](https://x.com/acker_code)
+  - Platform: Browser desktop; keyboard dan mouse, tanpa login. Klik arena untuk mengunci mouse; Esc untuk melepasnya.
+  - GPT-6 Astra: [Pernyataan kreator](https://x.com/acker_code/status/2097542957070975286) — Kreator secara eksplisit menyebut Codex dan GPT-6 Astra sebagai alat pembuatan game tembak-menembak bergaya ASCII ini. [Catatan verifikasi](assets/screenshots/ascii-district/SOURCE.md).
+  - Pratinjau: ![Halaman berkarakter ASCII dengan musuh virus yang mendekat dan HUD senapan menunjukkan 29 peluru setelah menembak.](assets/screenshots/ascii-district/gameplay.jpg)
+
+- **[Aura Farming: Unbothered](https://www.aigameshare.com/games/aura-farming-game)** — Jaga keseimbangan kapibara yang menari di perahu naga, miringkan tubuh melawan ombak, dan selesaikan enam gerakan sebelum waktu 40 detik habis.
+  - Kreator: [nilni / @nil](https://www.aigameshare.com/profile/nil)
+  - Platform: Browser desktop; gratis tanpa login. Klik Play; fitur akun bersifat opsional.
+  - GPT-6 Astra: [Halaman game dari kreator](https://www.aigameshare.com/games/aura-farming-game) — Kreator mencantumkan GPT-6 Astra dan Codex untuk game ini, bersama Blender, Three.js, ImageGen, dan WebAudio. [Catatan verifikasi](assets/screenshots/aura-farming/SOURCE.md).
+  - Pratinjau: ![Kapibara menari di perahu naga, dengan kontrol memiringkan tubuh dan menahan posisi serta HUD tantangan enam gerakan.](assets/screenshots/aura-farming/gameplay.jpg)
+
 <a id="puzzles"></a>
 
 ### Teka-teki dan asah otak
@@ -135,6 +199,25 @@ Teka-teki logika, tantangan fisika, permainan kata, dan mekanisme kecil yang kre
   - Keterlibatan model: [Catatan pembuatan](works/sunjing-puzzles/CREATION.md) — Pengembangan berulang melalui Codex untuk desain gim, visual 3D prosedural, aturan, pemecah teka-teki, dan pengujian; penggunaan spesifik GPT-6 Astra masih menunggu konfirmasi kreator (pengajuan draf).
   - Materi pengembangan: [Kode sumber dan petunjuk menjalankan](works/sunjing-puzzles/README.md) · [Kebutuhan](works/sunjing-puzzles/PROMPTS.md) · Teknologi: React, Vinext/Vite, Three.js.
   - Pratinjau: ![Teka-teki kayu enam bagian Sunjing di meja kerja 3D hijau dengan nomor bagian dan kontrol penarikan.](assets/screenshots/sunjing-puzzles/gameplay.jpg)
+
+- **[CityMaker](https://citymaker.0to1app.com)** — Puzzle 2048 di blok kota 4×4: gabungkan bangunan sejenis untuk menapaki sebelas tingkat arsitektur di tiap kota, dari rumah tradisional hingga cakrawala kota yang khas. Tersedia dua belas kota dengan sudut pandang yang dapat diputar 45° sekali putar.
+  - Kreator: [Derek Wang](https://github.com/derek-wangpch)
+  - Platform: Browser desktop dan seluler dengan WebGL; bahasa Inggris, Mandarin Sederhana, dan Mandarin Tradisional. Gratis, tanpa login atau kunci API; progres tiap kota tersimpan di browser yang digunakan. Dapat dipasang ke Layar Utama iOS.
+  - GPT-6 Astra: [Catatan pembuatan](https://github.com/derek-wangpch/OpenCityMaker/blob/master/docs/CREATION.md) — Kreator melaporkan penggunaan GPT-6 Astra untuk menghasilkan geometri prosedural seluruh 132 model bangunan, melalui alur berbasis referensi: riset dari berbagai sudut, pembentukan massa bangunan yang mendahulukan siluet, dan validasi tangkapan layar; bukan percobaan satu kali prompt.
+  - Referensi: [Kode sumber dan penyiapan](https://github.com/derek-wangpch/OpenCityMaker) · [Catatan verifikasi](https://github.com/derek-wangpch/OpenCityMaker/blob/master/QA.md) · Dibuat dengan: React, TypeScript, Vite, dan Three.js; seluruh 132 model bangunan merupakan geometri prosedural orisinal.
+  - Pratinjau: ![Papan Hong Kong di CityMaker dengan bangunan 3D low-poly pada kisi 4×4, skor, deretan pilihan kota, dan kontrol rotasi.](assets/screenshots/citymaker/gameplay.png)
+
+- **[Bonkshot](https://bonkshot.com/)** — Tarik ketapel dan lontarkan Bonker kecil ke penyangga kayu untuk merobohkan bangunan dan menyingkirkan sasaran.
+  - Kreator: [edmund5](https://x.com/edmund5)
+  - Platform: Browser; seret untuk membidik dan lepaskan untuk menembak. Bisa dimainkan tanpa login; login Google opsional.
+  - GPT-6 Astra: [Pernyataan kreator](https://x.com/edmund5/status/2097603093819261002) — Kreator menyebut GPT-6 Astra dan Three.js untuk game ini, dengan musik latar yang dibuat menggunakan Suno. [Catatan verifikasi](assets/screenshots/bonkshot/SOURCE.md).
+  - Pratinjau: ![Puzzle Grasslands pertama setelah tembakan, menampilkan menara kayu yang sebagian runtuh, satu sasaran tersisa, dan 2.200 poin.](assets/screenshots/bonkshot/gameplay.jpg)
+
+- **[Greenhouse Escape Room: The Last Seed](https://www.aigameshare.com/games/greenhouse-escape-room)** — Jelajahi rumah kaca yang terkunci, pulihkan pipa air tembaga, atur tanaman dan pantulan cahaya, lalu selamatkan benih terakhirnya.
+  - Kreator: [nilni / @nil](https://www.aigameshare.com/profile/nil)
+  - Platform: Browser; klik Play, lalu Begin. Gratis, tanpa login; kontrol dalam bahasa Inggris dan Mandarin.
+  - GPT-6 Astra: [Halaman game dari kreator](https://www.aigameshare.com/games/greenhouse-escape-room) — Kreator menyebut GPT-6 Astra dan Codex sebagai alat pengembangan, bersama ImageGen dan WebAudio. [Catatan verifikasi](assets/screenshots/greenhouse-escape-room/SOURCE.md).
+  - Pratinjau: ![Ruang Waterworks dalam game pelarian rumah kaca, dengan perangkat pipa sembilan petak, penghitung waktu, dan inventaris.](assets/screenshots/greenhouse-escape-room/gameplay.jpg)
 
 <a id="strategy-simulation"></a>
 
@@ -227,6 +310,24 @@ Pertahanan menara, kartu strategi, pengelolaan, pembangunan, dan sandbox simulas
   - Sumber daya: [GitHub](https://github.com/LucasMarquesShiva/the-free-game)
   - Pratinjau: ![The Free Game](assets/screenshots/the-free-game/gameplay.jpg)
 
+- **[AGI of Empires — The Compute Wars](https://agiofempires.com/)** — Kumpulkan pendanaan dan GPU, bangun pusat data dan pasukan, lalu dahului laboratorium AI pesaing dalam mencapai ASI atau hancurkan markas mereka.
+  - Kreator: [timour kosters](https://x.com/timourxyz)
+  - Platform: Browser desktop; game strategi waktu nyata satiris yang gratis. Pertandingan awal melawan komputer dan pengumpulan sumber daya telah diverifikasi tanpa login.
+  - GPT-6 Astra: [X](https://x.com/timourxyz/status/2096662786692776293) — Kreator menyatakan bahwa ia mengembangkan game yang terinspirasi Age of Empires ini dengan Astra selama dua hari. [Catatan verifikasi](assets/screenshots/agi-of-empires/SOURCE.md).
+  - Pratinjau: ![Medan perang AGI of Empires, penghitung sumber daya, dan markas.](assets/screenshots/agi-of-empires/gameplay.jpg)
+
+- **[Atlas Go](https://atlas-go.borisxp.chatgpt.site/)** — Mainkan Go pada jaringan jalan dan papan graf yang tidak biasa, dengan opsi bergantian pada satu perangkat dan bermain bersama teman.
+  - Kreator: [Boris Power](https://x.com/BorisMPower)
+  - Platform: Browser; papan lokal terbuka tanpa login. Pertandingan daring bersama teman belum diuji.
+  - GPT-6 Astra: [X](https://x.com/BorisMPower/status/2096784808399843582) — Kreator menyebut game Go multipemain pada graf sembarang ini sebagai hasil satu prompt Astra. [Catatan verifikasi](assets/screenshots/atlas-go/SOURCE.md).
+  - Pratinjau: ![Batu hitam dan putih pada papan graf sarang lebah Atlas Go.](assets/screenshots/atlas-go/gameplay.jpg)
+
+- **[Ironwood — The Art of Industry](https://ironwood.sparkles.dev/)** — Kumpulkan bahan mentah, alirkan daya ke mesin, dan sambungkan ban berjalan untuk mengubah lahan kosong menjadi pabrik yang beroperasi.
+  - Kreator: [Dan](https://x.com/aidaniil)
+  - Platform: Browser desktop; tutorial tamu terbuka tanpa login, tetapi penyimpanan progres memerlukan login. Multipemain belum diuji secara independen.
+  - GPT-6 Astra: [X](https://x.com/aidaniil/status/2096426970930106530) — Kreator menyatakan bahwa ia dan saudaranya membuat game ini dengan Astra, Blender MCP, dan Cloudflare Durable Objects, terinspirasi oleh Satisfactory dan Besiege. [Catatan verifikasi](assets/screenshots/ironwood/SOURCE.md).
+  - Pratinjau: ![Mesin pabrik Ironwood, ban berjalan, dan tutorial pengelolaan sumber daya.](assets/screenshots/ironwood/gameplay.jpg)
+
 - **[DUST FRONT](https://dust-front.mustafaakin.dev/)** — RTS pemain tunggal dengan pembangunan markas, perebutan lokasi serta komando pasukan darat dan udara.
   - Pembuat: [Mustafa Akın](https://x.com/mustafaakin)
   - Platform: Browser desktop; keyboard dan mouse, tanpa login wajib.
@@ -239,6 +340,18 @@ Pertahanan menara, kartu strategi, pengelolaan, pembangunan, dan sandbox simulas
   - GPT-6 Astra: [X](https://x.com/HDLhN783wtLkpPR/status/2097321360641122393) — Dalam unggahan yang ditautkan, kreator menyatakan menggunakan “GPT Astra” untuk membuat RTS ini; versi model yang tepat dan alur pengembangan terperinci tidak disebutkan.
   - Referensi: [Kiriman](https://github.com/MartinDelophy/awesome-gpt-6-astra/issues/66) · [Catatan verifikasi (bahasa Inggris)](assets/screenshots/frontline-command/SOURCE.md)
   - Pratinjau: ![Frontline Command: pangkalan, tiga tank terpilih, dan penempatan pembangkit listrik dalam pertandingan yang sedang berjalan; v0.8, diambil pada 2026-09-09.](assets/screenshots/frontline-command/gameplay.jpg)
+
+- **[Coin Pusher Roguelite: Mintfall](https://www.aigameshare.com/games/coin-pusher-roguelite-mintfall)** — Bidik mesin pendorong koin 3D, padukan koin khusus dan relik, lalu selesaikan enam ronde dengan jumlah jatuhan terbatas dan target skor.
+  - Kreator: [nilni / @nil](https://www.aigameshare.com/profile/nil)
+  - Platform: Browser; klik Play, gratis tanpa login. Penyimpanan melalui akun bersifat opsional.
+  - GPT-6 Astra: [Halaman game dari kreator](https://www.aigameshare.com/games/coin-pusher-roguelite-mintfall) — Kreator mencantumkan GPT-6 Astra bersama GPT-5.6 Sol dan Codex; halaman game tidak memisahkan kontribusi masing-masing. [Catatan verifikasi](assets/screenshots/mintfall/SOURCE.md).
+  - Pratinjau: ![Baki koin 3D Mintfall pada ronde pertama, menampilkan 33 poin, 44 jatuhan, dan kontrol koin khusus.](assets/screenshots/mintfall/gameplay.jpg)
+
+- **[Westward — The Oregon Trail](https://biswaz.me/westward/)** — Pimpin rombongan kereta ke barat, atur jatah makanan, perbaikan, dan perburuan, lalu buat keputusan sepanjang Oregon Trail.
+  - Kreator: [Biswas](https://x.com/bis_waz)
+  - Platform: Browser desktop; mulai dengan rombongan fiktif yang disediakan, tanpa login atau instalasi.
+  - GPT-6 Astra: [X](https://x.com/bis_waz/status/2098023593468907747) — Biswas menyatakan bahwa ia memakai GPT-6 Astra untuk membuat versi 3D modern The Oregon Trail ini dan menautkan game yang bisa dimainkan. [Catatan verifikasi](assets/screenshots/westward/SOURCE.md).
+  - Pratinjau: ![Kereta dan lembu di jalan menuju Kansas River, dengan jarak tempuh 25 mil dan panel perbekalan ekspedisi.](assets/screenshots/westward/gameplay.jpg)
 
 <a id="rpg-adventures"></a>
 
@@ -276,6 +389,63 @@ Permainan peran, eksplorasi, petualangan naratif, dan cerita interaktif.
   - Platform: Peramban desktop; dibuka tanpa login atau pembayaran. Seluler belum diuji.
   - GPT-6 Astra: [X](https://x.com/emollick/status/2096047660662722620) — Kreator menyatakan menggunakan Astra dalam pengembangan proyek ini. [Catatan verifikasi (Inggris)](assets/screenshots/zork/SOURCE.md).
   - Pratinjau: ![Zork · The Great Underground Empire](assets/screenshots/zork/gameplay.jpg)
+
+- **[The Simpsons: Hit & Run — Browser Recreation](https://vheissu.github.io/hit-and-run-web/)** — Jelajahi Springfield dengan berjalan kaki dan mengendarai mobil dalam versi buatan ulang tidak resmi untuk browser yang memiliki misi, lalu lintas, dan kejaran polisi.
+  - Kreator: [Dwayne](https://x.com/CtrlAltDwayne)
+  - Platform: Browser desktop; misi pertama berhasil dimuat tanpa login setelah pemuatan awal aset berukuran besar. Penyelesaian seluruh kampanye belum diuji.
+  - GPT-6 Astra: [X](https://x.com/CtrlAltDwayne/status/2096872309936287887) — Kreator menjelaskan pembangunan ulang game untuk web dengan GPT-6 Astra; repositori juga mencantumkan bantuan Claude dalam pemuatan. Hak atas aset game asli tetap milik pemegang haknya. [Catatan verifikasi](assets/screenshots/hit-and-run-web/SOURCE.md).
+  - Referensi: [Kode sumber dan penyiapan](https://github.com/Vheissu/hit-and-run-web)
+  - Pratinjau: ![Homer di Springfield dengan tujuan misi pertama dan peta mini yang terlihat.](assets/screenshots/hit-and-run-web/gameplay.jpg)
+
+- **[Where the Wind Wanders](https://app.usecrayon.ai/play/a9a3c165-74b3-4ff6-9588-ad97f829ddb5)** — Susuri lembah 2.5D bermandikan sinar matahari, ikuti jalur, dan kumpulkan tiga surat angin dalam petualangan eksplorasi yang tenang.
+  - Kreator: [Tushar](https://x.com/TusharXo)
+  - Platform: Browser, dihosting di Crayon; halaman game publik dan pemutar tersemat telah diperiksa.
+  - GPT-6 Astra: [X](https://x.com/TusharXo/status/2096037482739683574) — Tushar menjelaskan penggunaan Astra untuk menghasilkan jalur dan aset; unggahan lanjutan mengumumkan rilis yang bisa dimainkan dengan Astra, Three.js, dan Crayon. [Catatan verifikasi](assets/screenshots/crayon-adventure/SOURCE.md).
+  - Referensi: [Pengumuman rilis kreator](https://x.com/TusharXo/status/2096741535891251261)
+  - Pratinjau: ![Karakter menjelajahi lembah penuh bunga dengan tujuan pengumpulan surat angin yang terlihat.](assets/screenshots/crayon-adventure/gameplay.jpg)
+
+- **[ALIBI — The Last Light](https://alibi-blackthorn-manor.vercel.app/)** — Selidiki Blackthorn Manor dalam misteri pembunuhan tunjuk-dan-klik, periksa lokasi dan ikuti petunjuk untuk menemukan pembunuhnya.
+  - Kreator: [Christos Antonopoulos](https://x.com/Christos_antono)
+  - Platform: Browser; pintu masuk manor yang interaktif terbuka tanpa login. Adegan lanjutan yang dihasilkan belum diuji sepenuhnya.
+  - GPT-6 Astra: [X](https://x.com/Christos_antono/status/2096435122669297892) — Kreator mencantumkan GPT Astra dan H3 Max untuk game detektif generatif ini. [Catatan verifikasi](assets/screenshots/alibi-blackthorn-manor/SOURCE.md).
+  - Pratinjau: ![Pintu masuk manor dengan pintu yang dapat diklik dan teks pembuka penyelidikan.](assets/screenshots/alibi-blackthorn-manor/gameplay.jpg)
+
+- **[Skyward: The Gathering](https://edge-city-skyward-quests.vercel.app/)** — Jelajahi pulau-pulau terapung, melompat dan melayang antarkomunitas, serta selesaikan misi untuk para penghuninya.
+  - Kreator: [timour kosters](https://x.com/timourxyz)
+  - Platform: Browser desktop, keyboard dan mouse; halaman edisi misi dan kontrolnya telah diperiksa.
+  - GPT-6 Astra: [X](https://x.com/timourxyz/status/2096379521926840339) — Kreator menyatakan bahwa Astra membuat game 3D yang bisa dimainkan dengan NPC dan misi yang terinspirasi lokasi-lokasi Edge City. [Catatan verifikasi](assets/screenshots/skyward-gathering/SOURCE.md).
+  - Pratinjau: ![Gambaran pulau terapung Skyward dengan kontrol eksplorasi dan jurnal.](assets/screenshots/skyward-gathering/gameplay.jpg)
+
+- **[Anna & Leo · The Starstone Adventure](https://anna-leo-starstone.vercel.app/)** — Beralih antara sihir musik Anna dan kekuatan super Leo untuk membangunkan bunga melodi dan menjelajahi Wonder Garden.
+  - Kreator: [Dharma Utomo](https://x.com/dharmautomo)
+  - Platform: Browser; misi pembuka berhasil dimulai tanpa login. WASD untuk bergerak, Space untuk melompat, E untuk kekuatan, dan Tab untuk berganti pahlawan.
+  - GPT-6 Astra: [X](https://x.com/dharmautomo/status/2096573649235091967) — Kreator menyatakan bahwa GPT-6 Astra membantunya membuat petualangan 3D ini dan membagikan video anak-anaknya menguji game tersebut. [Catatan verifikasi](assets/screenshots/anna-leo-starstone/SOURCE.md).
+  - Pratinjau: ![Dunia petualangan 3D Anna dan Leo beserta antarmuka misinya.](assets/screenshots/anna-leo-starstone/gameplay.jpg)
+
+- **[The Legend of Deller](https://rain-court-js.umodeler-inc-4323.chatgpt.site/)** — Jelajahi Rainmist Haven dan menuju ruang bawah tanah dengan kombo pedang, keterampilan elemen, dan gerakan menghindar.
+  - Kreator: [UModeler X PicoBerry](https://x.com/UModeler)
+  - Platform: Browser desktop; keyboard dan mouse, tanpa login. Tunggu pemuatan awal aset 3D hingga selesai.
+  - GPT-6 Astra: [Pernyataan kreator](https://x.com/UModeler/status/2097792348407099553) — Kreator menyatakan bahwa PicoBerry menghasilkan aset, sementara GPT-6 Astra membangun RPG aksi berbasis Three.js yang menggunakan aset tersebut. [Catatan verifikasi](assets/screenshots/the-legend-of-deller/SOURCE.md).
+  - Referensi: [Tautan rilis dari kreator](https://x.com/UModeler/status/2097792351129178451)
+  - Pratinjau: ![Deller menghindar di Rainmist Haven dekat air mancur dan kios pasar, dengan kesehatan, mana, dan kontrol keterampilan.](assets/screenshots/the-legend-of-deller/gameplay.jpg)
+
+- **[Dungeon of Astra](https://wavedash.com/games/dungeon-of-astra)** — Rekrut kelompok, turuni ruang bawah tanah seratus lantai, dan gabungkan serangan pedang, bola api, serta peran rekan dalam petualangan dengan kematian permanen.
+  - Kreator: [tonysuri / @tonysurix](https://x.com/tonysurix)
+  - Platform: Browser desktop di Wavedash; game dasar dimulai tanpa login. Tersedia akun opsional dan pembukaan karakter lebih awal yang berbayar.
+  - GPT-6 Astra: [Pernyataan kreator](https://x.com/tonysurix/status/2097873333551616355) — Kreator secara eksplisit menyatakan bahwa game penjelajahan dungeon berkelompok ini dibuat dengan GPT-6 Astra. [Catatan verifikasi](assets/screenshots/dungeon-of-astra/SOURCE.md).
+  - Pratinjau: ![Pahlawan dan kesatria sewaan menggunakan bola api di lantai dungeon pertama, dengan kesehatan kelompok dan peta mini.](assets/screenshots/dungeon-of-astra/gameplay.jpg)
+
+- **[Sunlandia — The Forgotten Shore](https://sunlandia.smallweblab.com/)** — Jelajahi pulau setelah kapal karam, telusuri petunjuk dari sudut pandang orang pertama, dan pecahkan teka-teki lingkungan dalam perjalanan menuju mercusuar.
+  - Kreator: [Ramon Linares / Small Web Lab](https://github.com/RamonLinares)
+  - Platform: Browser desktop; tunggu pulau dimuat, lalu pilih Begin expedition. Gratis, tanpa akun atau instalasi.
+  - GPT-6 Astra: [Catatan pengembangan kreator](https://smallweblab.com/posts/sunlandia/) — Kreator memulai dengan GPT-5.6 Sol, mendapat bantuan dari Fable, dan menyelesaikan game dengan GPT-6 Astra. [Catatan verifikasi](assets/screenshots/sunlandia/SOURCE.md).
+  - Pratinjau: ![Pantai Sunlandia dari sudut pandang orang pertama, dengan bangkai kapal, dermaga rusak, dan tujuan mencari bantuan.](assets/screenshots/sunlandia/gameplay.jpg)
+
+- **[NÁCAR](https://nacar-microcosmo.preda2005.chatgpt.site/)** — Tumbuhkan organisme mikroskopis di dalam cangkang siput yang terendam, kumpulkan nutrisi, dan kembangkan bagian tubuh baru saat menjelajah.
+  - Kreator: [Marcio Lima / @Preda2005](https://x.com/Preda2005)
+  - Platform: Browser; beta gratis tanpa login, dengan lima bahasa antarmuka termasuk Mandarin.
+  - GPT-6 Astra: [Utas kreator](https://x.com/Preda2005/status/2097954217180921928) — Marcio menyatakan bahwa ia menjelaskan gagasan evolusi organisme ini kepada GPT-6 Astra dan mengembangkannya menjadi beta yang ditautkan. [Catatan verifikasi](assets/screenshots/nacar/SOURCE.md).
+  - Pratinjau: ![Sel kecil di antara nutrisi berwarna, dengan biomassa, evolusi, inventaris, dan kontrol wilayah air yang telah dijelajahi.](assets/screenshots/nacar/gameplay.jpg)
 
 <a id="platformers-racing"></a>
 
@@ -341,6 +511,31 @@ Parkour, tantangan platform, balapan, serta gim yang berfokus pada gerakan dan r
   - GPT-6 Astra: [Issue #51](https://github.com/MartinDelophy/awesome-gpt-6-astra/issues/51) — Menurut pembuat: Versi pertama dengan Qwen3.8 Max; versi kedua dibangun ulang sepenuhnya dengan Astra.
   - Pratinjau: ![疾风赛道 / Kart Racing（跑跑卡丁车）](https://github.com/user-attachments/assets/015e0ca1-7032-4d0e-9391-ad3f40d84227)
 
+- **[TIDAL RUSH — Paradise GP](https://tidal-rush-paradise-gp.skirano.chatgpt.site/)** — Lakukan drift di sirkuit kart tropis, gunakan item, dan hadapi tujuh pesaing selama tiga putaran.
+  - Kreator: [Pietro Schirano](https://x.com/skirano)
+  - Platform: Browser; balapan tiga putaran berhasil dimulai tanpa login. Kontrol keyboard untuk mengemudi, drift, dan item, ditambah tombol sentuh di layar.
+  - GPT-6 Astra: [Bukti penggunaan model](https://openai.com/index/gpt-6-astra/) — Halaman peluncuran Astra dari OpenAI menautkan game kart interaktif ini dan mencantumkan Pietro Schirano sebagai kreatornya. Unggahan penemuan di X merupakan kiriman komunitas, bukan unggahan kreator sendiri. [Catatan verifikasi](assets/screenshots/tidal-rush/SOURCE.md).
+  - Referensi: [Temuan di X](https://x.com/alexgetmancom/status/2095598460921614825)
+  - Pratinjau: ![Lintasan kart tropis Tidal Rush dengan posisi balapan dan kontrol drift.](assets/screenshots/tidal-rush/gameplay.jpg)
+
+- **[LUNA — Crimson Requiem / 紅月のレクイエム](https://luna-crimson-requiem.ponsuke.chatgpt.site/)** — Lompati level seni piksel gotik, tebas atau injak musuh, atau panggil serangan dalam petualangan singkat dengan gulir samping.
+  - Kreator: [音羽ぽんすけ](https://x.com/ponsuke_otowa)
+  - Platform: Browser, antarmuka Jepang; kontrol keyboard dan dukungan ponsel yang dilaporkan kreator. Tersedia satu level.
+  - GPT-6 Astra: [X](https://x.com/ponsuke_otowa/status/2096531744933425299) — Kreator melaporkan sekitar 25 menit pengembangan dengan Astra dan satu perbaikan animasi berjalan; musik dikreditkan secara terpisah kepada Suno. [Catatan verifikasi](assets/screenshots/luna-crimson-requiem/SOURCE.md).
+  - Pratinjau: ![LUNA bertarung di jalan gotik di bawah bulan merah, dengan meter kesehatan dan pemanggilan.](assets/screenshots/luna-crimson-requiem/gameplay.jpg)
+
+- **[Strange Orbit](https://app.usecrayon.ai/play/47df78e2-1410-45d1-833c-196e1161c0b8)** — Balapkan pesepeda astronaut di cincin planet, kumpulkan debu bintang, manfaatkan aliran udara di belakang pesaing, dan melaju dengan dorongan dalam Orbital Cup.
+  - Kreator: [Crayon](https://x.com/usecrayon)
+  - Platform: Browser di Crayon; kontrol keyboard dan kontrol sentuh yang dijelaskan dalam dokumentasi. Halaman publik menawarkan mode balapan, uji waktu, dan penjelajahan tanpa akhir.
+  - GPT-6 Astra: [X](https://x.com/usecrayon/status/2097468975995302167) — Crayon mencantumkan GPT-6 Astra, Crayon Pro, dan Three.js untuk game bersepeda luar angkasa ini. [Catatan verifikasi](assets/screenshots/crayon-space-bike/SOURCE.md).
+  - Pratinjau: ![Pesepeda astronaut berlomba di cincin planet, dengan indikator putaran, posisi, dan debu bintang.](assets/screenshots/crayon-space-bike/gameplay.jpg)
+
+- **[One More Vine — Into the Wild](https://onemorevine.bennash.dev/)** — Berlari, melompat, dan berayun melintasi empat level hutan, kumpulkan harta, dan hindari buaya sambil memperbaiki catatan waktu.
+  - Kreator: [Ben Nash](https://x.com/bennash)
+  - Platform: Browser, keyboard dan kontrol gerakan di layar; level pembuka dan petunjuk dimuat tanpa login.
+  - GPT-6 Astra: [X](https://x.com/bennash/status/2096282758930645170) — Kreator secara eksplisit menyebutnya game empat level yang terinspirasi Pitfall dan dibuat dengan GPT-6 Astra. [Catatan verifikasi](assets/screenshots/one-more-vine/SOURCE.md).
+  - Pratinjau: ![Level platformer hutan dengan sulur menggantung, harta, lubang, dan buaya.](assets/screenshots/one-more-vine/gameplay.jpg)
+
 - **[混合马里奥Ⅱ · 忍者龙剑传 × 坦克大战 / Mario Mix II](https://aha-xiaoq.github.io/games/mario-mix-2/play.html)** — Jelajahi dunia bawah tanah 1-2 dari Mario bersama Ryu Hayabusa dari Ninja Gaiden dan tank Battle City: melompat, memanjat dinding, dan bertarung dengan tampilan samping sebagai Ryu, bertempur dari sudut pandang atas sebagai tank, atau menyelamatkan putri lewat estafet ninja lalu tank.
   - Kreator: [在下_小Q（Aha-xiaoQ）](https://github.com/Aha-xiaoQ)
   - Platform: Peramban desktop, antarmuka bahasa Mandarin, papan ketik disarankan; gratis, tanpa login atau instalasi.
@@ -349,6 +544,37 @@ Parkour, tantangan platform, balapan, serta gim yang berfokus pada gerakan dan r
   - Hak: Gim penggemar tidak resmi; hak atas karakter, gambar, dan musik klasik tetap milik pemegang hak masing-masing. Kredit materi tersedia di halaman gim asli.
   - Pratinjau: ![Mario Mix II — sampul video yang diberikan kreator, bukan tangkapan permainan.](https://aha-xiaoq.github.io/games/mario-mix-2/cover.jpg)
   - Tangkapan layar: ![Tank Mario Mix II menembak di pintu masuk dunia 1-2; versi 1.0 sedang berjalan, diambil pada 2026-09-09.](assets/screenshots/mario-mix-2/gameplay.jpg)
+
+- **[Bengaluru ORR Rush](https://orr-rush-bengaluru.ravitheja.chatgpt.site/)** — Balapan di tengah lalu lintas Bengaluru, hindari jalan berlubang dan motor pengantar, lalu gunakan dorongan atau ayunan ke samping untuk membuka ruang.
+  - Kreator: [Ravi Theja](https://x.com/ravithejads)
+  - Platform: Browser desktop; kontrol keyboard dengan gas otomatis opsional, tanpa login.
+  - GPT-6 Astra: [Pernyataan kreator](https://x.com/ravithejads/status/2097181044625887392) — Kreator mengaitkan pembuatan game balap jalanan Bengaluru ini dengan GPT-6 Astra. [Catatan verifikasi](assets/screenshots/bengaluru-orr-rush/SOURCE.md).
+  - Pratinjau: ![Mobil biru pemain di lalu lintas Bengaluru, dengan posisi balapan, kecepatan, penghitung waktu, dan petunjuk kontrol.](assets/screenshots/bengaluru-orr-rush/gameplay.jpg)
+
+- **[SKICROSS — Alpine Downhill](https://iamsonic.net/2026/mini-games/skicross.html)** — Balapan menuruni gunung melawan tiga pemain ski, lewati gerbang dan rintangan, serta tetap mendahului longsoran salju.
+  - Kreator: [Sonic的奇思妙想](https://x.com/sonic0828)
+  - Platform: Browser desktop; A/D untuk mengarahkan, Space untuk melompat, dan Shift untuk dorongan; tanpa login atau unduhan.
+  - GPT-6 Astra: [Pernyataan kreator](https://x.com/sonic0828/status/2097601232877781344) — Kreator menyebut GPT-6 Astra untuk koleksi mini-game ini dan membagikan game ski tersebut dalam balasan khusus. [Catatan verifikasi](assets/screenshots/skicross/SOURCE.md).
+  - Referensi: [Tautan rilis dari kreator](https://x.com/sonic0828/status/2097601732297814300)
+  - Pratinjau: ![Empat pemain ski di lintasan bersalju, dengan bonus gerbang, peringkat, kecepatan, dan indikator jarak longsoran.](assets/screenshots/skicross/gameplay.jpg)
+
+- **[Itsy Bitsy Spider · One More Climb](https://game-bench.piccini.app/games/gpt-6-astra/)** — Panjat dinding berlumut, tangkap lalat untuk memulihkan daya cengkeram, dan bersembunyilah di lubang perlindungan sebelum hujan menghanyutkan laba-laba.
+  - Kreator: [Luiz Piccini](https://piccini.app/)
+  - Platform: Browser; gratis tanpa login. WASD atau joystick di layar.
+  - GPT-6 Astra: [Game Bench milik kreator](https://game-bench.piccini.app/) — Game Bench memberi label karya terbit ini sebagai GPT-6 Astra canary, high, bertanggal 2026-09-05, dibuat dari arahan game bersama milik platform tersebut. [Catatan verifikasi](assets/screenshots/itsy-bitsy-spider/SOURCE.md).
+  - Pratinjau: ![Laba-laba memanjat dinding bata berlumut pada ketinggian 2 meter, dengan daya cengkeram, lalat, tempat berlindung, dan joystick gerakan.](assets/screenshots/itsy-bitsy-spider/gameplay.jpg)
+
+- **[Desi Mayhem](https://desimayhem.com/)** — Balapkan sepeda motor di tengah lalu lintas kota India, selip di antara bus dan bajaj sambil memakai tendangan, pukulan, dan dorongan.
+  - Kreator: [Kishore](https://x.com/GetKishore)
+  - Platform: Browser desktop; gratis tanpa akun. Terima atau edit nama panggilan pengendara yang dihasilkan sebelum perjalanan pertama.
+  - GPT-6 Astra: [Utas pengembangan kreator](https://x.com/GetKishore/status/2097906401159102811) — Kishore menjelaskan penyempurnaan game 3D buatan Astra dengan referensi jalanan serta pengujian berulang terhadap lalu lintas, tabrakan, dan pertarungan pengendara. [Catatan verifikasi](assets/screenshots/desi-mayhem/SOURCE.md).
+  - Pratinjau: ![Balapan motor di Chennai dengan pengendara pemain, lalu lintas kota, peta mini, posisi, dan penghitung waktu balapan.](assets/screenshots/desi-mayhem/gameplay.jpg)
+
+- **[Cosmic Tides](https://app.usecrayon.ai/play/362ae1e7-29bd-4fbc-9103-00649265d942)** — Kendarai wahana melintasi samudra galaktik, ikuti gerbang bercahaya, dan pilih balapan dua putaran atau hanyut tanpa akhir.
+  - Kreator: [Aniket J](https://x.com/aniketjart)
+  - Platform: Browser; tunggu aset 3D, lalu pilih Ride the current. Gratis tanpa login.
+  - GPT-6 Astra: [X](https://x.com/aniketjart/status/2098207146647433534) — Aniket mencantumkan GPT-6 Astra, Blender MCP, dan Crayon untuk game ini; ia menyebutnya eksperimen dengan rencana penyempurnaan gameplay lebih lanjut. [Catatan verifikasi](assets/screenshots/cosmic-tides/SOURCE.md).
+  - Pratinjau: ![Balapan Cosmic Tides yang sedang berlangsung, mendekati gerbang bercahaya di atas laut galaktik dengan indikator putaran dan kecepatan.](assets/screenshots/cosmic-tides/gameplay.jpg)
 
 <a id="experimental-multiplayer"></a>
 
@@ -394,6 +620,12 @@ Mekanisme tidak biasa, kompetisi daring, dan pengalaman bermain kooperatif.
   - Platform: Peramban, gratis, tanpa akun. Pembuat menyebut VPN/proksi mungkin diperlukan. Awal solo diuji; multipemain belum diuji.
   - GPT-6 Astra: [Issue #52](https://github.com/MartinDelophy/awesome-gpt-6-astra/issues/52) — Menurut pembuat: Versi pertama dengan GPT-6 Astra Pro; perbaikan berikutnya dengan GPT-6 Astra di Codex.
   - Pratinjau: ![泡泡坦克大作战联机版 / Toon Tank Arena](https://github.com/user-attachments/assets/713d44f3-a77c-452c-ba6d-1231882dc670)
+
+- **[Above the Rooftops](https://app.usecrayon.ai/play/d09bb865-2259-42e2-86cc-fb609a9d6f28)** — Warnai layang-layang dan terbangkan di atas atap kota, atur ketegangan benang dalam penerbangan bebas atau tantangan mengumpulkan cahaya langit berbatas waktu.
+  - Kreator: [Tushar / @TusharXo](https://x.com/TusharXo)
+  - Platform: Browser; pilih karakter, masuk ke atap, lalu pilih Fly. Gratis tanpa login.
+  - GPT-6 Astra: [X](https://x.com/TusharXo/status/2098156783181467801) — Tushar secara eksplisit menyebut GPT-6 Astra dan Crayon untuk game layang-layang Three.js ini serta Images 2.5 untuk visualnya. [Catatan verifikasi](assets/screenshots/above-the-rooftops/SOURCE.md).
+  - Pratinjau: ![Tantangan layang-layang di atas kota, dengan ketinggian, ketegangan benang, progres cahaya langit, dan kontrol arah.](assets/screenshots/above-the-rooftops/gameplay.jpg)
 
 ## Isi setiap entri
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -4,7 +4,7 @@
 
 # Awesome GPT-6 Astra
 
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](CONTRIBUTING.md) [![LINUX DO](https://img.shields.io/badge/LINUX%20DO-Community-f0b73f?style=flat-square)](https://linux.do/) [![Cases: 49](https://img.shields.io/badge/Cases-49-58a6ff?style=flat-square)](https://astragames.aigccreative.com/)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](CONTRIBUTING.md) [![LINUX DO](https://img.shields.io/badge/LINUX%20DO-Community-f0b73f?style=flat-square)](https://linux.do/) [![Cases: 86](https://img.shields.io/badge/Cases-86-58a6ff?style=flat-square)](https://astragames.aigccreative.com/)
 
 **GPT-6 Astra で作られた、遊んでみたくなるゲームを集めています。**
 
@@ -22,7 +22,7 @@
 
 ## はじめに
 
-現在、**49件のゲームとインタラクティブ作品**を掲載しています。三国志の領土戦略、木製の組木パズルとスライドパズル、柔らかい果物の合成、ワンボタン飛行、魔法の絨毯での戦闘、島の電力網を使うタワーディフェンス、荒野でのサバイバル、水中での魚捕り、寿司店経営と島での農作業、海湾サーキットのカートレース、ペリカンとの海岸サイクリング、卓上玩具の 3D ゲーム化、そして Orbital Garden。作品名をクリックすると、ブラウザーで直接遊べます。
+現在、**86件のゲームとインタラクティブ作品**を掲載しています。三国志の領土戦略、木製の組木パズルとスライドパズル、柔らかい果物の合成、プロシージャルな都市建設 2048、ワンボタン飛行、魔法の絨毯での戦闘、全5ステージの弾幕シューティング、島の電力網を使うタワーディフェンス、荒野でのサバイバル、水中での魚捕り、寿司店経営と島での農作業、海湾サーキットのカートレース、ペリカンとの海岸サイクリング、卓上玩具の 3D ゲーム化、3D の室内装飾、そして Orbital Garden。作品名をクリックすると、ブラウザーで直接遊べます。
 
 一覧更新日：**2026-09-12**。モデルの利用情報は作者または投稿者の説明に基づき、未確認の内容は各項目に明記しています。この日付は一覧の更新日であり、全作品を再度プレイテストした日ではありません。
 
@@ -110,6 +110,70 @@
   - GPT-6 Astra: [X](https://x.com/jumperz/status/2096600055301984738) — 作者は本作の開発に Astra を使用したと述べています。 [検証記録（英語）](assets/screenshots/cinderfall/SOURCE.md).
   - プレビュー: ![Cinderfall · Fire, Shadow & Steel](assets/screenshots/cinderfall/gameplay.jpg)
 
+- **[Oz Breakdance](https://satriodewantono.com/breakdance/)** — ラグドールのダンサーの手足を対応する目標へドラッグし、得点を稼いで制限時間つきのブレイキンのラウンドを延長します。
+  - 作者: [Satrio](https://x.com/satrio_d)
+  - プラットフォーム: デスクトップブラウザー、マウス操作。ログインなしで時間制限つきラウンドの開始を確認しました。
+  - GPT-6 Astra: [X](https://x.com/satrio_d/status/2096022866097758500) — 作者は、Astra が既存のブレイクダンスゲームとその見せ方を改善したと説明しています。 [検証メモ](assets/screenshots/breakdance/SOURCE.md).
+  - プレビュー: ![制限時間つきのダンス場で足の目標を狙うラグドールダンサー。](assets/screenshots/breakdance/gameplay.jpg)
+
+- **[Astral War](https://astralwar.io/)** — 第二次世界大戦を題材にしたブラウザー FPS。兵士やゾンビの外見、武器装備、ボット練習、ロビーの選択肢があります。
+  - 作者: [Rishi](https://x.com/0xRishi)
+  - プラットフォーム: デスクトップブラウザー、キーボードとマウス。ログインなしでボット練習を開始済み。マルチプレイとコントローラーは未検証です。
+  - GPT-6 Astra: [X](https://x.com/0xRishi/status/2096079660605997264) — Rishi は Astra、Three.js、Meshy、ElevenLabs で制作したと説明しています。現行サイトには Vesper のクレジットもあり、帰属については検証メモを参照してください。 [検証メモ](assets/screenshots/astral-war/SOURCE.md).
+  - プレビュー: ![武器と戦闘操作が見える Astral War の実行中の戦闘画面。](assets/screenshots/astral-war/gameplay.jpg)
+
+- **[FLOP CLUB](https://bubucn.com/ai-model-evals/flop-club/game/index.html)** — 3 段階の高さから飛び込み、宙返りやひねりを決め、浮かぶリングを狙って入水の得点を伸ばします。
+  - 作者: [BubuAi](https://x.com/BubuStd)
+  - プラットフォーム: ブラウザー。単体ゲームはログインやダウンロードなしで起動します。2026-09-09 の確認で飛び込みを開始済み。キーボードと説明に記載されたタッチ操作に対応。
+  - GPT-6 Astra: [X](https://x.com/BubuStd/status/2096402783805354091) — 作者は Astra Pro と Three.js を使い、1 回のプロンプトで制作したと報告しています。 [検証メモ](assets/screenshots/flop-club/SOURCE.md).
+  - 開発資料: [プロジェクト紹介](https://bubucn.com/zh/ai-model-evals/flop-club)
+  - プレビュー: ![目標リングの上にある高い台の選手と入水操作。](assets/screenshots/flop-club/gameplay.jpg)
+
+- **[Vector Dive — Beyond the Signal](https://vector-dive.openai.chatgpt.site/)** — 周回ごとに加速するネオンのワイヤーフレームコースを飛行し、ブーストやフェーズ移動のタイミングを合わせて生き延びます。
+  - 作者: [Thomas Ricouard](https://x.com/Dimillian)
+  - プラットフォーム: デスクトップブラウザー。ログインなしで得点つき飛行を開始済み。WASD で飛行、Space でブースト、Shift でフェーズ移動。
+  - GPT-6 Astra: [X](https://x.com/Dimillian/status/2097188900888322323) — 作者はネオン／シンセウェーブのビジュアル方針とコンセプトアートから、Astra がゲームと音楽を作ったと説明しています。 [検証メモ](assets/screenshots/vector-dive/SOURCE.md).
+  - プレビュー: ![Vector Dive のネオンコース、プレイヤー機体、ゲーム HUD。](assets/screenshots/vector-dive/gameplay.jpg)
+
+- **[Harbor Skirmish](https://gpt6astra-game.vercel.app/)** — 3 種の武器、屋根上のルート、ダッシュ、グラップルを使い、押し寄せる暴れウサギから海辺の町を守ります。
+  - 作者: [OpenDesign](https://x.com/OpenDesignHQ)
+  - プラットフォーム: デスクトップブラウザー、キーボードとマウス。ログインやダウンロードは不要です。
+  - GPT-6 Astra: [作者の説明](https://x.com/OpenDesignHQ/status/2097635757917983223) — OpenDesign は 2 モデルの比較で、この Three.js ゲームを GPT-6 Astra による作品と明記しています。 [検証メモ](assets/screenshots/harbor-skirmish/SOURCE.md).
+  - プレビュー: ![Seabreeze の一人称ライフル視点。迫るウサギ、ウェーブ数、武器操作も表示。](assets/screenshots/harbor-skirmish/gameplay.jpg)
+
+- **[UNDERGROUND — Underground Boxing](https://iamsonic.net/2026/mini-games/underground-boxing.html)** — 地下の 3D リングで時間制限つきの 3 ラウンドを戦い、パンチ、防御、回避とスタミナを管理します。
+  - 作者: [Sonic的奇思妙想](https://x.com/sonic0828)
+  - プラットフォーム: デスクトップブラウザー。WASD で移動、J/K でパンチ、L で防御、Space で回避。ログインやダウンロードは不要です。
+  - GPT-6 Astra: [作者の説明](https://x.com/sonic0828/status/2097601232877781344) — 作者の作品紹介スレッドはミニゲーム生成に GPT-6 Astra を使ったと記載し、ボクシングの返信でこの版を公開しています。 [検証メモ](assets/screenshots/underground-boxing/SOURCE.md).
+  - 開発資料: [作者の公開リンク](https://x.com/sonic0828/status/2097601584410796401)
+  - プレビュー: ![照明のある地下リングで打ち合う 2 人のボクサー。ラウンド時間、体力、スタミナを表示。](assets/screenshots/underground-boxing/gameplay.jpg)
+
+- **[Urban Champion 3D](https://iamsonic.net/2026/mini-games/urban-champion.html)** — 夕暮れの通りで上段・下段パンチを繰り出し、反撃を防ぎ、落ちる植木鉢を避けながら相手をマンホールへ追い込みます。
+  - 作者: [Sonic的奇思妙想](https://x.com/sonic0828)
+  - プラットフォーム: デスクトップブラウザー。A/D で移動、J/K でパンチ、U/I で防御、Space で回避。ログイン不要。
+  - GPT-6 Astra: [作者の説明](https://x.com/sonic0828/status/2097601232877781344) — 作者の GPT-6 Astra 作品紹介には、この路上格闘ゲームへのリンクを含む個別の公開返信があります。 [検証メモ](assets/screenshots/urban-champion-3d/SOURCE.md).
+  - 開発資料: [作者の公開リンク](https://x.com/sonic0828/status/2097601861658587376)
+  - プレビュー: ![Sunset Mart 前で戦う青と赤の選手、ラウンド時間とスタミナゲージ。](assets/screenshots/urban-champion-3d/gameplay.jpg)
+
+- **[Zero District — Shells 3D](https://iamsonic.net/2026/mini-games/shells-3d/play.html)** — 自動射撃、移動による回避、経験値回収、選べる強化を使い、3 分間の市街戦を生き延びます。
+  - 作者: [Sonic的奇思妙想](https://x.com/sonic0828)
+  - プラットフォーム: ブラウザー。WASD またはドラッグで移動し、自動で照準を合わせます。ログインやダウンロード不要。
+  - GPT-6 Astra: [作者の説明](https://x.com/sonic0828/status/2097601232877781344) — 作者はコレクション告知で GPT-6 Astra を明記し、個別の返信でこの 3D サバイバル版を紹介しています。 [検証メモ](assets/screenshots/zero-district-shells-3d/SOURCE.md).
+  - 開発資料: [作者の公開リンク](https://x.com/sonic0828/status/2097602391122264310)
+  - プレビュー: ![街路で周囲の敵へ自動射撃する生存者。撃破数 14、残り 166 秒。](assets/screenshots/zero-district-shells-3d/gameplay.jpg)
+
+- **[ASCII DISTRICT](https://ascii-district.vercel.app/)** — ASCII 文字で描かれた一人称アリーナで、疾走、ジャンプ、スライディングを使い、コンピューターウイルスの敵の波を迎え撃ちます。
+  - 作者: [Acker Code](https://x.com/acker_code)
+  - プラットフォーム: デスクトップブラウザー、キーボードとマウス。ログイン不要。アリーナをクリックしてマウスを捕捉し、Esc で解除します。
+  - GPT-6 Astra: [作者の説明](https://x.com/acker_code/status/2097542957070975286) — 作者はこの ASCII アートのシューティングを Codex と GPT-6 Astra で制作したと明記しています。 [検証メモ](assets/screenshots/ascii-district/SOURCE.md).
+  - プレビュー: ![ウイルスが迫る ASCII の中庭。射撃後のライフル HUD は残弾 29。](assets/screenshots/ascii-district/gameplay.jpg)
+
+- **[Aura Farming: Unbothered](https://www.aigameshare.com/games/aura-farming-game)** — ドラゴンボート上で踊るカピバラのバランスを取り、波に合わせて傾け、40 秒以内に 6 つの動きを成功させます。
+  - 作者: [nilni / @nil](https://www.aigameshare.com/profile/nil)
+  - プラットフォーム: デスクトップブラウザー。無料、ログイン不要。Play をクリック。アカウント機能は任意です。
+  - GPT-6 Astra: [作者の掲載ページ](https://www.aigameshare.com/games/aura-farming-game) — 作者は GPT-6 Astra と Codex に加え、Blender、Three.js、ImageGen、WebAudio をクレジットしています。 [検証メモ](assets/screenshots/aura-farming/SOURCE.md).
+  - プレビュー: ![ボートで踊るカピバラ、傾きと踏ん張りの操作、6 つの動きの課題 HUD。](assets/screenshots/aura-farming/gameplay.jpg)
+
 <a id="puzzles"></a>
 
 ### パズル・頭脳ゲーム
@@ -135,6 +199,25 @@
   - モデルの担当範囲: [制作記録](works/sunjing-puzzles/CREATION.md) — Codex でゲーム設計、手続き型の 3D グラフィックス、ルール、ソルバー、テストを繰り返し開発。GPT-6 Astra の具体的な利用は作者の確認待ちです（草稿としての投稿）。
   - 開発資料: [ソースコードと実行手順](works/sunjing-puzzles/README.md) · [要件の記録](works/sunjing-puzzles/PROMPTS.md) · 使用技術: React, Vinext/Vite, Three.js.
   - プレビュー: ![Sunjing の 6 部品の木製パズル。緑の 3D 作業台に、部品番号と引き抜き操作を表示しています。](assets/screenshots/sunjing-puzzles/gameplay.jpg)
+
+- **[CityMaker](https://citymaker.0to1app.com)** — 4×4 の街区で遊ぶ 2048 パズル。同じ建物を合成して都市ごとに 11 段階の建築を発展させ、伝統家屋から特徴的なスカイラインへ。12 都市を収録し、視点は 45° ずつ回転できます。
+  - 作者: [Derek Wang](https://github.com/derek-wangpch)
+  - プラットフォーム: WebGL 対応のデスクトップ・モバイルブラウザー。英語、簡体字・繁体字中国語。無料でログインや API キー不要。都市ごとの進行状況を現在のブラウザーに保存し、iOS ホーム画面にも追加できます。
+  - GPT-6 Astra: [制作記録](https://github.com/derek-wangpch/OpenCityMaker/blob/master/docs/CREATION.md) — 作者は 132 棟すべてのプロシージャルジオメトリを GPT-6 Astra で生成したと説明しています。参照資料に基づく多方向の調査、シルエットを重視したボリューム作成、画像による検証を重ねたもので、1 回のプロンプトのテストではありません。
+  - 開発資料: [ソースとセットアップ](https://github.com/derek-wangpch/OpenCityMaker) · [検証メモ](https://github.com/derek-wangpch/OpenCityMaker/blob/master/QA.md) · 技術：React、TypeScript、Vite、Three.js。132 の建物モデルはすべて独自のプロシージャルジオメトリです。
+  - プレビュー: ![香港の CityMaker 盤面。4×4 のローポリ 3D 建物、得点、都市選択と回転操作。](assets/screenshots/citymaker/gameplay.png)
+
+- **[Bonkshot](https://bonkshot.com/)** — パチンコを引いて小さな Bonkers を木の支柱へ飛ばし、構造物を崩して目標を倒します。
+  - 作者: [edmund5](https://x.com/edmund5)
+  - プラットフォーム: ブラウザー。ドラッグで狙い、放して発射。ログインせずにプレイでき、Google ログインは任意です。
+  - GPT-6 Astra: [作者の説明](https://x.com/edmund5/status/2097603093819261002) — 作者はゲームに GPT-6 Astra と Three.js、背景音楽に Suno を使用したと記載しています。 [検証メモ](assets/screenshots/bonkshot/SOURCE.md).
+  - プレビュー: ![Grasslands の最初のパズルで発射した後。崩れかけの木塔、残り目標 1、2,200 点。](assets/screenshots/bonkshot/gameplay.jpg)
+
+- **[Greenhouse Escape Room: The Last Seed](https://www.aigameshare.com/games/greenhouse-escape-room)** — 閉ざされた温室を探索し、銅の水道管を修理し、植物や反射光を配置して最後の種を救い出します。
+  - 作者: [nilni / @nil](https://www.aigameshare.com/profile/nil)
+  - プラットフォーム: ブラウザー。Play、続いて Begin をクリック。無料、ログイン不要。操作表示は英語と中国語。
+  - GPT-6 Astra: [作者の掲載ページ](https://www.aigameshare.com/games/greenhouse-escape-room) — 作者は開発ツールとして GPT-6 Astra、Codex、ImageGen、WebAudio を挙げています。 [検証メモ](assets/screenshots/greenhouse-escape-room/SOURCE.md).
+  - プレビュー: ![温室脱出ゲームの Waterworks 室。9 マスの配管装置、タイマー、所持品。](assets/screenshots/greenhouse-escape-room/gameplay.jpg)
 
 <a id="strategy-simulation"></a>
 
@@ -227,6 +310,24 @@
   - 開発資料: [GitHub](https://github.com/LucasMarquesShiva/the-free-game)
   - プレビュー: ![The Free Game](assets/screenshots/the-free-game/gameplay.jpg)
 
+- **[AGI of Empires — The Compute Wars](https://agiofempires.com/)** — 資金と GPU を集め、データセンターと軍隊を築き、ライバル AI 研究所より先に ASI を目指すか、本部を破壊します。
+  - 作者: [timour kosters](https://x.com/timourxyz)
+  - プラットフォーム: デスクトップブラウザー。無料の風刺リアルタイム戦略ゲーム。ログインなしで対コンピューター戦の開始と資源収集を確認済み。
+  - GPT-6 Astra: [X](https://x.com/timourxyz/status/2096662786692776293) — 作者は Age of Empires に着想を得たこのゲームを Astra で 2 日間かけて開発したと説明しています。 [検証メモ](assets/screenshots/agi-of-empires/SOURCE.md).
+  - プレビュー: ![AGI of Empires の戦場、資源カウンター、本部。](assets/screenshots/agi-of-empires/gameplay.jpg)
+
+- **[Atlas Go](https://atlas-go.borisxp.chatgpt.site/)** — 道路網や変則的なグラフ盤で囲碁をプレイ。1 台で交代するローカル対局や、友人との対局の選択肢があります。
+  - 作者: [Boris Power](https://x.com/BorisMPower)
+  - プラットフォーム: ブラウザー。ログインなしでローカル盤面を開くことを確認済み。オンラインの友人対局は未検証。
+  - GPT-6 Astra: [X](https://x.com/BorisMPower/status/2096784808399843582) — 作者は任意のグラフ上で遊ぶマルチプレイ囲碁を、Astra への 1 回のプロンプトで制作したと説明しています。 [検証メモ](assets/screenshots/atlas-go/SOURCE.md).
+  - プレビュー: ![Atlas Go のハニカム型グラフ盤に置かれた黒石と白石。](assets/screenshots/atlas-go/gameplay.jpg)
+
+- **[Ironwood — The Art of Industry](https://ironwood.sparkles.dev/)** — 原材料を集め、機械へ電力を供給し、ベルトコンベヤーをつないで空き地を稼働する工場へ育てます。
+  - 作者: [Dan](https://x.com/aidaniil)
+  - プラットフォーム: デスクトップブラウザー。ゲスト用チュートリアルはログイン不要ですが、進行状況の保存にはログインが必要です。マルチプレイは独立検証していません。
+  - GPT-6 Astra: [X](https://x.com/aidaniil/status/2096426970930106530) — 作者は兄弟で Astra、Blender MCP、Cloudflare Durable Objects を使って制作し、Satisfactory と Besiege に着想を得たと説明しています。 [検証メモ](assets/screenshots/ironwood/SOURCE.md).
+  - プレビュー: ![Ironwood の機械、コンベヤー、資源管理チュートリアル。](assets/screenshots/ironwood/gameplay.jpg)
+
 - **[DUST FRONT](https://dust-front.mustafaakin.dev/)** — 基地建設、拠点占領、陸空部隊の指揮を楽しむシングルプレイヤーRTS。
   - 作者: [Mustafa Akın](https://x.com/mustafaakin)
   - プラットフォーム: デスクトップブラウザー。キーボードとマウス、ログイン不要。
@@ -239,6 +340,18 @@
   - GPT-6 Astra: [X](https://x.com/HDLhN783wtLkpPR/status/2097321360641122393) — 作者はリンク先の投稿で、この RTS の制作に「GPT Astra」を使用したと述べています。具体的なモデルのバージョンと詳しい開発手順は示されていません。
   - 参考資料: [投稿](https://github.com/MartinDelophy/awesome-gpt-6-astra/issues/66) · [検証記録（英語）](assets/screenshots/frontline-command/SOURCE.md)
   - プレビュー: ![Frontline Command の対戦画面。基地、選択中の戦車3両、発電所の配置操作。v0.8、2026-09-09 撮影。](assets/screenshots/frontline-command/gameplay.jpg)
+
+- **[Coin Pusher Roguelite: Mintfall](https://www.aigameshare.com/games/coin-pusher-roguelite-mintfall)** — 3D コインプッシャーで狙いを定め、特殊コインとレリックを組み合わせ、限られた投入回数で得点目標を達成し 6 ラウンドを攻略します。
+  - 作者: [nilni / @nil](https://www.aigameshare.com/profile/nil)
+  - プラットフォーム: ブラウザー。Play をクリック。無料、ログイン不要。アカウントでの保存は任意です。
+  - GPT-6 Astra: [作者の掲載ページ](https://www.aigameshare.com/games/coin-pusher-roguelite-mintfall) — 作者は GPT-6 Astra、GPT-5.6 Sol、Codex を併記しており、それぞれの担当範囲は説明していません。 [検証メモ](assets/screenshots/mintfall/SOURCE.md).
+  - プレビュー: ![Mintfall の第 1 ラウンドの 3D コイントレイ。33 点、投入 44 回、特殊コイン操作。](assets/screenshots/mintfall/gameplay.jpg)
+
+- **[Westward — The Oregon Trail](https://biswaz.me/westward/)** — 幌馬車の一行を西へ導き、食料を配分し、修理や狩りを管理しながらオレゴン街道で選択を重ねます。
+  - 作者: [Biswas](https://x.com/bis_waz)
+  - プラットフォーム: デスクトップブラウザー。用意された架空の一行で開始でき、ログインやインストールは不要です。
+  - GPT-6 Astra: [X](https://x.com/bis_waz/status/2098023593468907747) — Biswas は GPT-6 Astra で The Oregon Trail の現代的な 3D 版を制作したと述べ、ゲームを公開しています。 [検証メモ](assets/screenshots/westward/SOURCE.md).
+  - プレビュー: ![カンザス川へ向かう牛と幌馬車。移動 25 マイル、物資管理パネル。](assets/screenshots/westward/gameplay.jpg)
 
 <a id="rpg-adventures"></a>
 
@@ -276,6 +389,63 @@
   - 対応環境: デスクトップブラウザー。ログイン・支払いなしで起動を確認。モバイルは未検証。
   - GPT-6 Astra: [X](https://x.com/emollick/status/2096047660662722620) — 作者は本作の開発に Astra を使用したと述べています。 [検証記録（英語）](assets/screenshots/zork/SOURCE.md).
   - プレビュー: ![Zork · The Great Underground Empire](assets/screenshots/zork/gameplay.jpg)
+
+- **[The Simpsons: Hit & Run — Browser Recreation](https://vheissu.github.io/hit-and-run-web/)** — 非公式のブラウザー再制作版で Springfield を徒歩や車で探索。ミッション、交通、警察の追跡があります。
+  - 作者: [Dwayne](https://x.com/CtrlAltDwayne)
+  - プラットフォーム: デスクトップブラウザー。大量の初期リソース読込後、ログインなしで最初のミッションを開始できました。全キャンペーンの完走は未検証。
+  - GPT-6 Astra: [X](https://x.com/CtrlAltDwayne/status/2096872309936287887) — 作者は GPT-6 Astra で Web 向けに再構築したと説明し、リポジトリは読込に関する Claude の補助も記載しています。原作の素材には元の権利が適用されます。 [検証メモ](assets/screenshots/hit-and-run-web/SOURCE.md).
+  - 開発資料: [ソースとセットアップ](https://github.com/Vheissu/hit-and-run-web)
+  - プレビュー: ![Springfield の Homer。最初のミッション目標とミニマップを表示。](assets/screenshots/hit-and-run-web/gameplay.jpg)
+
+- **[Where the Wind Wanders](https://app.usecrayon.ai/play/a9a3c165-74b3-4ff6-9588-ad97f829ddb5)** — 陽光が差す 2.5D の谷を歩き、道をたどって 3 通の風の手紙を集める穏やかな探索アドベンチャー。
+  - 作者: [Tushar](https://x.com/TusharXo)
+  - プラットフォーム: ブラウザー、Crayon 上で公開。公開ページと埋め込みプレイヤーを確認済み。
+  - GPT-6 Astra: [X](https://x.com/TusharXo/status/2096037482739683574) — Tushar は Astra による道と素材の生成を説明し、続報で Astra、Three.js、Crayon を使ったプレイ可能版の公開を告知しています。 [検証メモ](assets/screenshots/crayon-adventure/SOURCE.md).
+  - 開発資料: [作者の公開告知](https://x.com/TusharXo/status/2096741535891251261)
+  - プレビュー: ![花咲く谷を探索するキャラクターと風の手紙の目標。](assets/screenshots/crayon-adventure/gameplay.jpg)
+
+- **[ALIBI — The Last Light](https://alibi-blackthorn-manor.vercel.app/)** — ポイント＆クリックの殺人ミステリーで Blackthorn Manor を調べ、場面を観察して手がかりを追い、犯人を突き止めます。
+  - 作者: [Christos Antonopoulos](https://x.com/Christos_antono)
+  - プラットフォーム: ブラウザー。ログインなしで操作可能な屋敷の入口を開けました。その後に生成される場面は十分に検証していません。
+  - GPT-6 Astra: [X](https://x.com/Christos_antono/status/2096435122669297892) — 作者はこの生成型の探偵ゲームに GPT Astra と H3 Max の両方を使用したと記載しています。 [検証メモ](assets/screenshots/alibi-blackthorn-manor/SOURCE.md).
+  - プレビュー: ![クリックできる扉のある屋敷の入口と、捜査開始の文章。](assets/screenshots/alibi-blackthorn-manor/gameplay.jpg)
+
+- **[Skyward: The Gathering](https://edge-city-skyward-quests.vercel.app/)** — 浮遊島を探索し、集落の間をジャンプや滑空で渡り、住民の依頼をこなします。
+  - 作者: [timour kosters](https://x.com/timourxyz)
+  - プラットフォーム: デスクトップブラウザー、キーボードとマウス。クエスト版のページと操作説明を確認済み。
+  - GPT-6 Astra: [X](https://x.com/timourxyz/status/2096379521926840339) — 作者は Edge City の場所に着想を得た NPC とクエストのある 3D ゲームを Astra が作ったと説明しています。 [検証メモ](assets/screenshots/skyward-gathering/SOURCE.md).
+  - プレビュー: ![Skyward の浮遊島の全景と探索・日誌の操作。](assets/screenshots/skyward-gathering/gameplay.jpg)
+
+- **[Anna & Leo · The Starstone Adventure](https://anna-leo-starstone.vercel.app/)** — Anna の音楽魔法と Leo の超能力を切り替え、メロディーの花を目覚めさせて Wonder Garden を探索します。
+  - 作者: [Dharma Utomo](https://x.com/dharmautomo)
+  - プラットフォーム: ブラウザー。ログインなしで最初のクエストを開始済み。WASD で移動、Space でジャンプ、E で能力、Tab で主人公交代。
+  - GPT-6 Astra: [X](https://x.com/dharmautomo/status/2096573649235091967) — 作者は GPT-6 Astra が 3D アドベンチャー制作を助けたと述べ、子どもたちが試遊する動画も公開しています。 [検証メモ](assets/screenshots/anna-leo-starstone/SOURCE.md).
+  - プレビュー: ![Anna と Leo の 3D アドベンチャー世界とクエスト画面。](assets/screenshots/anna-leo-starstone/gameplay.jpg)
+
+- **[The Legend of Deller](https://rain-court-js.umodeler-inc-4323.chatgpt.site/)** — Rainmist Haven を探索し、剣の連撃、属性スキル、回避移動を使ってダンジョンへ向かいます。
+  - 作者: [UModeler X PicoBerry](https://x.com/UModeler)
+  - プラットフォーム: デスクトップブラウザー、キーボードとマウス。ログイン不要。最初の 3D 素材の読込完了を待ってください。
+  - GPT-6 Astra: [作者の説明](https://x.com/UModeler/status/2097792348407099553) — 作者は PicoBerry が素材を生成し、GPT-6 Astra がそれらを使う Three.js のアクション RPG を構築したと説明しています。 [検証メモ](assets/screenshots/the-legend-of-deller/SOURCE.md).
+  - 開発資料: [作者の公開リンク](https://x.com/UModeler/status/2097792351129178451)
+  - プレビュー: ![Rainmist Haven の噴水と露店の近くで回避する Deller。体力、マナ、スキル操作。](assets/screenshots/the-legend-of-deller/gameplay.jpg)
+
+- **[Dungeon of Astra](https://wavedash.com/games/dungeon-of-astra)** — 仲間を雇い、100 階のダンジョンへ降り、剣や火球、仲間の役割を組み合わせます。死亡すると復活できない冒険です。
+  - 作者: [tonysuri / @tonysurix](https://x.com/tonysurix)
+  - プラットフォーム: Wavedash のデスクトップブラウザーゲーム。基本プレイはログイン不要。アカウントは任意で、キャラクターの早期解放には有料の選択肢があります。
+  - GPT-6 Astra: [作者の説明](https://x.com/tonysurix/status/2097873333551616355) — 作者はこのパーティー型ダンジョン探索ゲームを GPT-6 Astra で制作したと明言しています。 [検証メモ](assets/screenshots/dungeon-of-astra/SOURCE.md).
+  - プレビュー: ![最初の階で火球を放つ主人公と雇った騎士。パーティーの体力とミニマップ。](assets/screenshots/dungeon-of-astra/gameplay.jpg)
+
+- **[Sunlandia — The Forgotten Shore](https://sunlandia.smallweblab.com/)** — 難破後の島を一人称で探索し、手がかりを調べ、環境を使うパズルを解きながら灯台を目指します。
+  - 作者: [Ramon Linares / Small Web Lab](https://github.com/RamonLinares)
+  - プラットフォーム: デスクトップブラウザー。島の読込を待ち、Begin expedition を選択。無料、アカウントやインストール不要。
+  - GPT-6 Astra: [作者の開発日誌](https://smallweblab.com/posts/sunlandia/) — 作者は GPT-5.6 Sol で始め、Fable の助けを受け、GPT-6 Astra でゲームを完成させました。 [検証メモ](assets/screenshots/sunlandia/SOURCE.md).
+  - プレビュー: ![Sunlandia の一人称の海岸。難破船、壊れた桟橋、助けを探す目標。](assets/screenshots/sunlandia/gameplay.jpg)
+
+- **[NÁCAR](https://nacar-microcosmo.preda2005.chatgpt.site/)** — 水に満ちたカタツムリの殻で微小生物を育て、栄養を集め、探索しながら新しい体の部位を発達させます。
+  - 作者: [Marcio Lima / @Preda2005](https://x.com/Preda2005)
+  - プラットフォーム: ブラウザー。無料ベータ、ログイン不要。中国語を含む 5 言語の UI。
+  - GPT-6 Astra: [作者のスレッド](https://x.com/Preda2005/status/2097954217180921928) — Marcio は生物進化の構想を GPT-6 Astra に伝え、公開中のベータまで開発したと説明しています。 [検証メモ](assets/screenshots/nacar/SOURCE.md).
+  - プレビュー: ![色とりどりの栄養に囲まれた細胞。バイオマス、進化、所持品、探索済み水域の表示。](assets/screenshots/nacar/gameplay.jpg)
 
 <a id="platformers-racing"></a>
 
@@ -341,6 +511,31 @@
   - GPT-6 Astra: [Issue #51](https://github.com/MartinDelophy/awesome-gpt-6-astra/issues/51) — 作者の説明： 初版はQwen3.8 Max、第2版はAstraで全面再構築。
   - プレビュー: ![疾风赛道 / Kart Racing（跑跑卡丁车）](https://github.com/user-attachments/assets/015e0ca1-7032-4d0e-9391-ad3f40d84227)
 
+- **[TIDAL RUSH — Paradise GP](https://tidal-rush-paradise-gp.skirano.chatgpt.site/)** — 南国のカートコースをドリフトし、アイテムを使い、7 人のライバルと 3 周のレースを競います。
+  - 作者: [Pietro Schirano](https://x.com/skirano)
+  - プラットフォーム: ブラウザー。ログインなしで 3 周のレースを開始済み。キーボードで運転・ドリフト・アイテム操作、画面上のタッチボタンもあります。
+  - GPT-6 Astra: [モデル利用の根拠](https://openai.com/index/gpt-6-astra/) — OpenAI の Astra 発表ページはこのカートゲームにリンクし、Pietro Schirano を作者として紹介しています。発見元の X 投稿は作者本人ではなくコミュニティによる共有です。 [検証メモ](assets/screenshots/tidal-rush/SOURCE.md).
+  - 開発資料: [X での紹介](https://x.com/alexgetmancom/status/2095598460921614825)
+  - プレビュー: ![Tidal Rush の南国カートコース、順位とドリフト操作。](assets/screenshots/tidal-rush/gameplay.jpg)
+
+- **[LUNA — Crimson Requiem / 紅月のレクイエム](https://luna-crimson-requiem.ponsuke.chatgpt.site/)** — ゴシックなピクセルアートのステージでジャンプし、敵を斬る、踏む、攻撃を召喚するといった操作で進む短い横スクロール冒険です。
+  - 作者: [音羽ぽんすけ](https://x.com/ponsuke_otowa)
+  - プラットフォーム: ブラウザー、日本語 UI。キーボード操作と作者が説明するスマートフォン対応。公開ステージは 1 つです。
+  - GPT-6 Astra: [X](https://x.com/ponsuke_otowa/status/2096531744933425299) — 作者は Astra で約 25 分開発し、歩行アニメーションを 1 回修正したと報告しています。音楽は別途 Suno のクレジットです。 [検証メモ](assets/screenshots/luna-crimson-requiem/SOURCE.md).
+  - プレビュー: ![赤い月のゴシック街路で戦う LUNA。体力と召喚ゲージ。](assets/screenshots/luna-crimson-requiem/gameplay.jpg)
+
+- **[Strange Orbit](https://app.usecrayon.ai/play/47df78e2-1410-45d1-833c-196e1161c0b8)** — 宇宙飛行士の自転車で惑星のリングを走り、星屑を集め、相手のスリップストリームとブーストを使って Orbital Cup を競います。
+  - 作者: [Crayon](https://x.com/usecrayon)
+  - プラットフォーム: Crayon 上のブラウザーゲーム。キーボードと説明に記載されたタッチ操作。公開ページにはレース、タイムトライアル、無限散策モードがあります。
+  - GPT-6 Astra: [X](https://x.com/usecrayon/status/2097468975995302167) — Crayon は宇宙自転車ゲームに GPT-6 Astra、Crayon Pro、Three.js を使用したと記載しています。 [検証メモ](assets/screenshots/crayon-space-bike/SOURCE.md).
+  - プレビュー: ![惑星のリングを走る宇宙飛行士たち。周回、順位、星屑の表示。](assets/screenshots/crayon-space-bike/gameplay.jpg)
+
+- **[One More Vine — Into the Wild](https://onemorevine.bennash.dev/)** — 4 つのジャングルステージを走り、跳び、つるに揺られ、宝を集めてワニを避けながらタイムを縮めます。
+  - 作者: [Ben Nash](https://x.com/bennash)
+  - プラットフォーム: ブラウザー、キーボードと画面上の移動操作。最初のステージと操作説明をログインなしで読込済み。
+  - GPT-6 Astra: [X](https://x.com/bennash/status/2096282758930645170) — 作者は GPT-6 Astra で作った、Pitfall に着想を得た 4 ステージのゲームと明記しています。 [検証メモ](assets/screenshots/one-more-vine/SOURCE.md).
+  - プレビュー: ![つる、宝、穴、ワニがあるジャングルのプラットフォームステージ。](assets/screenshots/one-more-vine/gameplay.jpg)
+
 - **[混合马里奥Ⅱ · 忍者龙剑传 × 坦克大战 / Mario Mix II](https://aha-xiaoq.github.io/games/mario-mix-2/play.html)** — 『忍者龍剣伝』のリュウ・ハヤブサと『バトルシティー』の戦車で、マリオの地下ステージ 1-2 に挑戦。リュウは横スクロールでジャンプ・壁登り・戦闘、戦車は見下ろし型の戦闘を行い、忍者から戦車へのリレーで姫を救うこともできます。
   - 作者: [在下_小Q（Aha-xiaoQ）](https://github.com/Aha-xiaoQ)
   - 対応環境: デスクトップブラウザー、中国語 UI、キーボード推奨。無料でログインやインストールは不要です。
@@ -349,6 +544,37 @@
   - 素材について: 非公式ファンゲームです。既存のキャラクター・画像・音楽の権利は各権利者に帰属します。素材のクレジットは元のゲームページを参照してください。
   - プレビュー: ![Mario Mix II — 作者提供の動画サムネイル。実際のプレイ画面の撮影ではありません。](https://aha-xiaoq.github.io/games/mario-mix-2/cover.jpg)
   - スクリーンショット: ![Mario Mix II の戦車がステージ 1-2 の入口で発砲する画面。バージョン 1.0、2026-09-09 撮影。](assets/screenshots/mario-mix-2/gameplay.jpg)
+
+- **[Bengaluru ORR Rush](https://orr-rush-bengaluru.ravitheja.chatgpt.site/)** — Bengaluru の交通を縫って走り、路面の穴や配達バイクを避け、ブーストや横振りで進路を切り開きます。
+  - 作者: [Ravi Theja](https://x.com/ravithejads)
+  - プラットフォーム: デスクトップブラウザー。キーボード操作、自動アクセルは任意。ログイン不要。
+  - GPT-6 Astra: [作者の説明](https://x.com/ravithejads/status/2097181044625887392) — 作者は Bengaluru の道路レースゲームを GPT-6 Astra で制作したと説明しています。 [検証メモ](assets/screenshots/bengaluru-orr-rush/SOURCE.md).
+  - プレビュー: ![Bengaluru の交通の中の青いプレイヤー車。順位、速度、時計、操作ヒント。](assets/screenshots/bengaluru-orr-rush/gameplay.jpg)
+
+- **[SKICROSS — Alpine Downhill](https://iamsonic.net/2026/mini-games/skicross.html)** — 3 人のスキーヤーと山を滑り降り、ゲートと障害物を越え、雪崩に追いつかれないように走ります。
+  - 作者: [Sonic的奇思妙想](https://x.com/sonic0828)
+  - プラットフォーム: デスクトップブラウザー。A/D で操舵、Space でジャンプ、Shift でブースト。ログインやダウンロード不要。
+  - GPT-6 Astra: [作者の説明](https://x.com/sonic0828/status/2097601232877781344) — 作者はミニゲーム集を GPT-6 Astra によるものと説明し、個別の返信でこのスキーゲームを公開しています。 [検証メモ](assets/screenshots/skicross/SOURCE.md).
+  - 開発資料: [作者の公開リンク](https://x.com/sonic0828/status/2097601732297814300)
+  - プレビュー: ![雪のコースを進む 4 人のスキーヤー。ゲートボーナス、順位、速度、雪崩までの距離。](assets/screenshots/skicross/gameplay.jpg)
+
+- **[Itsy Bitsy Spider · One More Climb](https://game-bench.piccini.app/games/gpt-6-astra/)** — 苔むした壁を登り、ハエを捕まえてグリップを回復し、雨に流される前に避難用の穴へ隠れます。
+  - 作者: [Luiz Piccini](https://piccini.app/)
+  - プラットフォーム: ブラウザー。無料、ログイン不要。WASD または画面上のジョイスティック。
+  - GPT-6 Astra: [作者の Game Bench](https://game-bench.piccini.app/) — Game Bench は公開作品を GPT-6 Astra canary、high、2026-09-05 と表示し、共通のゲーム制作課題から作られたものとしています。 [検証メモ](assets/screenshots/itsy-bitsy-spider/SOURCE.md).
+  - プレビュー: ![苔むしたレンガ壁の高さ 2 メートルにいるクモ。グリップ、ハエ、避難穴、ジョイスティック。](assets/screenshots/itsy-bitsy-spider/gameplay.jpg)
+
+- **[Desi Mayhem](https://desimayhem.com/)** — インドの街の交通をバイクで駆け抜け、バスやオートリキシャを避けながらキック、パンチ、ブーストを使います。
+  - 作者: [Kishore](https://x.com/GetKishore)
+  - プラットフォーム: デスクトップブラウザー。無料、アカウント不要。初走行前に生成されたライダー名を承認または編集します。
+  - GPT-6 Astra: [作者の開発スレッド](https://x.com/GetKishore/status/2097906401159102811) — Kishore は Astra 製の 3D ゲームを、街路の資料と交通・衝突・ライダー同士の戦闘の反復テストで改善した過程を説明しています。 [検証メモ](assets/screenshots/desi-mayhem/SOURCE.md).
+  - プレビュー: ![Chennai のバイクレース。ライダー、交通、ミニマップ、順位、レース時計。](assets/screenshots/desi-mayhem/gameplay.jpg)
+
+- **[Cosmic Tides](https://app.usecrayon.ai/play/362ae1e7-29bd-4fbc-9103-00649265d942)** — 銀河の海を乗り物で進み、光るゲートをたどって、2 周のレースか無限の漂流を選びます。
+  - 作者: [Aniket J](https://x.com/aniketjart)
+  - プラットフォーム: ブラウザー。3D 素材の読込後に Ride the current を選択。無料、ログイン不要。
+  - GPT-6 Astra: [X](https://x.com/aniketjart/status/2098207146647433534) — Aniket は GPT-6 Astra、Blender MCP、Crayon をクレジットし、今後もゲームプレイを改善する予定の実験と説明しています。 [検証メモ](assets/screenshots/cosmic-tides/SOURCE.md).
+  - プレビュー: ![銀河の海の光るゲートへ向かう Cosmic Tides のレース。周回と速度の表示。](assets/screenshots/cosmic-tides/gameplay.jpg)
 
 <a id="experimental-multiplayer"></a>
 
@@ -394,6 +620,12 @@
   - 対応環境: ブラウザー、無料、ログイン不要。作者によるとVPN／プロキシが必要な場合があります。ソロ開始を確認、マルチプレイは未検証。
   - GPT-6 Astra: [Issue #52](https://github.com/MartinDelophy/awesome-gpt-6-astra/issues/52) — 作者の説明： 初版はGPT-6 Astra Pro、以後の改善はCodexのGPT-6 Astra。
   - プレビュー: ![泡泡坦克大作战联机版 / Toon Tank Arena](https://github.com/user-attachments/assets/713d44f3-a77c-452c-ba6d-1231882dc670)
+
+- **[Above the Rooftops](https://app.usecrayon.ai/play/d09bb865-2259-42e2-86cc-fb609a9d6f28)** — 凧を彩り、糸の張りを調整しながら街の屋根上を飛ばします。自由飛行と、時間制限つきで空の光を集める課題があります。
+  - 作者: [Tushar / @TusharXo](https://x.com/TusharXo)
+  - プラットフォーム: ブラウザー。キャラクターを選び、屋上に入って Fly を選択。無料、ログイン不要。
+  - GPT-6 Astra: [X](https://x.com/TusharXo/status/2098156783181467801) — Tushar は Three.js の凧ゲームに GPT-6 Astra と Crayon を使ったと明記し、画像には Images 2.5 を挙げています。 [検証メモ](assets/screenshots/above-the-rooftops/SOURCE.md).
+  - プレビュー: ![街の上の凧揚げ課題。高度、糸の張り、空の光の進捗、操舵表示。](assets/screenshots/above-the-rooftops/gameplay.jpg)
 
 ## 各作品に記載する情報
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -4,7 +4,7 @@
 
 # Awesome GPT-6 Astra
 
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](CONTRIBUTING.md) [![LINUX DO](https://img.shields.io/badge/LINUX%20DO-Community-f0b73f?style=flat-square)](https://linux.do/) [![Cases: 49](https://img.shields.io/badge/Cases-49-58a6ff?style=flat-square)](https://astragames.aigccreative.com/)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](CONTRIBUTING.md) [![LINUX DO](https://img.shields.io/badge/LINUX%20DO-Community-f0b73f?style=flat-square)](https://linux.do/) [![Cases: 86](https://img.shields.io/badge/Cases-86-58a6ff?style=flat-square)](https://astragames.aigccreative.com/)
 
 **GPT-6 Astra로 만든 흥미로운 게임을 모았습니다.**
 
@@ -22,7 +22,7 @@
 
 ## 여기서 시작하기
 
-현재 **게임 및 인터랙티브 작품 49개**를 소개합니다. 삼국지 영토 전략, 나무 결합 퍼즐과 슬라이딩 퍼즐, 부드러운 과일 합치기, 원버튼 비행, 마법 양탄자 전투, 섬의 전력망을 이용한 타워 디펜스, 야생 생존, 수중 낚시와 초밥집 경영 및 섬 농사, 베이 서킷 카트 레이싱, 펠리컨과 함께하는 해안 자전거 달리기, 탁상 장난감을 옮긴 3D 게임, 그리고 Orbital Garden을 만나 보세요. 작품명을 누르면 브라우저에서 바로 플레이할 수 있습니다.
+현재 **게임 및 인터랙티브 작품 86개**를 소개합니다. 삼국지 영토 전략, 나무 결합 퍼즐과 슬라이딩 퍼즐, 부드러운 과일 합치기, 절차적 도시 건설 2048, 원버튼 비행, 마법 양탄자 전투, 5개 스테이지의 탄막 슈팅, 섬의 전력망을 이용한 타워 디펜스, 야생 생존, 수중 낚시와 초밥집 경영 및 섬 농사, 베이 서킷 카트 레이싱, 펠리컨과 함께하는 해안 자전거 달리기, 탁상 장난감을 옮긴 3D 게임, 3D 집 꾸미기, 그리고 Orbital Garden을 만나 보세요. 작품명을 누르면 브라우저에서 바로 플레이할 수 있습니다.
 
 목록 업데이트: **2026-09-12**. 모델 사용 정보는 제작자 또는 제출자의 설명을 바탕으로 하며, 미확인 내용은 각 항목에 표시합니다. 이 날짜는 목록 관리 날짜이며 모든 게임을 다시 플레이 테스트한 날짜가 아닙니다.
 
@@ -110,6 +110,70 @@
   - GPT-6 Astra: [X](https://x.com/jumperz/status/2096600055301984738) — 제작자는 이 프로젝트 개발에 Astra를 사용했다고 밝혔습니다. [검증 기록 (영어)](assets/screenshots/cinderfall/SOURCE.md).
   - 미리보기: ![Cinderfall · Fire, Shadow & Steel](assets/screenshots/cinderfall/gameplay.jpg)
 
+- **[Oz Breakdance](https://satriodewantono.com/breakdance/)** — 래그돌 댄서의 팔다리를 해당 목표 지점으로 끌어 점수를 얻고 제한 시간 브레이킹 라운드를 연장하세요.
+  - 제작자: [Satrio](https://x.com/satrio_d)
+  - 플랫폼: 데스크톱 브라우저, 마우스 조작. 로그인 없이 제한 시간 라운드가 시작되는 것을 확인했습니다.
+  - GPT-6 Astra: [X](https://x.com/satrio_d/status/2096022866097758500) — 제작자는 Astra로 기존 브레이크댄스 게임과 시각적 표현을 개선했다고 설명합니다. [검증 기록](assets/screenshots/breakdance/SOURCE.md).
+  - 미리보기: ![제한 시간 브레이크댄스 경기장에서 발 목표 지점을 노리는 래그돌 댄서.](assets/screenshots/breakdance/gameplay.jpg)
+
+- **[Astral War](https://astralwar.io/)** — 군인과 좀비 외형, 무기 장비 설정, 봇 훈련과 로비 옵션을 갖춘 제2차 세계대전 테마의 브라우저 FPS입니다.
+  - 제작자: [Rishi](https://x.com/0xRishi)
+  - 플랫폼: 데스크톱 브라우저, 키보드와 마우스. 로그인 없이 봇 훈련이 시작되었으며, 멀티플레이와 컨트롤러 지원은 테스트하지 않았습니다.
+  - GPT-6 Astra: [X](https://x.com/0xRishi/status/2096079660605997264) — Rishi는 Astra, Three.js, Meshy, ElevenLabs로 Astral War를 만들었다고 밝힙니다. 현재 사이트에는 Vesper도 명시되어 있으며, 관련 기여 설명은 검증 기록을 참고하세요. [검증 기록](assets/screenshots/astral-war/SOURCE.md).
+  - 미리보기: ![무기와 전장 조작 UI가 표시된 Astral War의 전투 화면.](assets/screenshots/astral-war/gameplay.jpg)
+
+- **[FLOP CLUB](https://bubucn.com/ai-model-evals/flop-club/game/index.html)** — 세 가지 높이의 플랫폼에서 다이빙하고 공중제비와 비틀기를 수행하며, 물 위의 링을 겨냥해 착수 점수를 높이세요.
+  - 제작자: [BubuAi](https://x.com/BubuStd)
+  - 플랫폼: 브라우저. 독립 실행 페이지에서 로그인이나 다운로드 없이 바로 시작합니다. 2026-09-09 검증에서 다이빙을 시작했으며, 키보드 조작과 문서에 기재된 터치 조작을 제공합니다.
+  - GPT-6 Astra: [X](https://x.com/BubuStd/status/2096402783805354091) — 제작자는 Three.js를 사용해 Astra Pro에 프롬프트 하나만 입력하여 만들었다고 설명합니다. [검증 기록](assets/screenshots/flop-club/SOURCE.md).
+  - 자료: [프로젝트 소개](https://bubucn.com/zh/ai-model-evals/flop-club)
+  - 미리보기: ![목표 링 위의 높은 플랫폼에 선 다이버와 착수 조작 UI.](assets/screenshots/flop-club/gameplay.jpg)
+
+- **[Vector Dive — Beyond the Signal](https://vector-dive.openai.chatgpt.site/)** — 매 바퀴마다 빨라지는 네온 와이어프레임 코스를 비행하며 부스트와 위상 이동의 타이밍을 맞춰 더 오래 살아남으세요.
+  - 제작자: [Thomas Ricouard](https://x.com/Dimillian)
+  - 플랫폼: 데스크톱 브라우저. 로그인 없이 점수제 비행이 시작되었습니다. WASD로 비행, Space로 부스트, Shift로 위상 이동을 합니다.
+  - GPT-6 Astra: [X](https://x.com/Dimillian/status/2097188900888322323) — 제작자는 네온·신스웨이브 시각 기획과 콘셉트 아트를 바탕으로 Astra가 게임과 음악을 만들었다고 설명합니다. [검증 기록](assets/screenshots/vector-dive/SOURCE.md).
+  - 미리보기: ![플레이어 기체와 게임 HUD가 보이는 Vector Dive의 네온 비행 코스.](assets/screenshots/vector-dive/gameplay.jpg)
+
+- **[Harbor Skirmish](https://gpt6astra-game.vercel.app/)** — 세 가지 무기, 지붕 위 경로, 대시와 갈고리로 몰려오는 말썽꾸러기 토끼들로부터 해안 마을을 지키세요.
+  - 제작자: [OpenDesign](https://x.com/OpenDesignHQ)
+  - 플랫폼: 데스크톱 브라우저. 키보드와 마우스 조작이며 로그인이나 다운로드가 필요 없습니다.
+  - GPT-6 Astra: [제작자 설명](https://x.com/OpenDesignHQ/status/2097635757917983223) — OpenDesign은 두 모델의 결과물을 비교하면서 이 Three.js 게임이 GPT-6 Astra로 만든 버전이라고 명시합니다. [검증 기록](assets/screenshots/harbor-skirmish/SOURCE.md).
+  - 미리보기: ![Seabreeze 마을을 바라보는 1인칭 소총 시점, 다가오는 토끼들, 웨이브 카운터와 무기 조작 UI.](assets/screenshots/harbor-skirmish/gameplay.jpg)
+
+- **[UNDERGROUND — Underground Boxing](https://iamsonic.net/2026/mini-games/underground-boxing.html)** — 3D 지하 링에서 제한 시간이 있는 세 라운드 동안 펀치, 막기, 회피와 스태미나를 관리하며 권투를 즐기세요.
+  - 제작자: [Sonic的奇思妙想](https://x.com/sonic0828)
+  - 플랫폼: 데스크톱 브라우저. WASD 이동, J/K 펀치, L 막기, Space 회피. 로그인이나 다운로드가 필요 없습니다.
+  - GPT-6 Astra: [제작자 설명](https://x.com/sonic0828/status/2097601232877781344) — 제작자는 작품 모음 스레드에서 이 미니게임들을 생성한 도구로 GPT-6 Astra를 명시했으며, 권투 게임 답글에 이 버전을 연결했습니다. [검증 기록](assets/screenshots/underground-boxing/SOURCE.md).
+  - 자료: [제작자의 공개 링크](https://x.com/sonic0828/status/2097601584410796401)
+  - 미리보기: ![조명이 켜진 지하 링에서 주먹을 주고받는 두 선수와 라운드 타이머, 체력 및 스태미나 표시.](assets/screenshots/underground-boxing/gameplay.jpg)
+
+- **[Urban Champion 3D](https://iamsonic.net/2026/mini-games/urban-champion.html)** — 해 질 녘 거리에서 상단·하단 펀치를 주고받고 반격을 막아 상대를 맨홀로 밀어 넣으세요. 떨어지는 화분도 피해야 합니다.
+  - 제작자: [Sonic的奇思妙想](https://x.com/sonic0828)
+  - 플랫폼: 데스크톱 브라우저. A/D 이동, J/K 펀치, U/I 막기, Space 회피. 로그인은 필요 없습니다.
+  - GPT-6 Astra: [제작자 설명](https://x.com/sonic0828/status/2097601232877781344) — 제작자의 GPT-6 Astra 작품 모음에는 이 거리 격투 게임의 링크가 담긴 별도 공개 답글이 있습니다. [검증 기록](assets/screenshots/urban-champion-3d/SOURCE.md).
+  - 자료: [제작자의 공개 링크](https://x.com/sonic0828/status/2097601861658587376)
+  - 미리보기: ![Sunset Mart 앞에서 싸우는 파란색·빨간색 격투가와 라운드 타이머, 스태미나 바.](assets/screenshots/urban-champion-3d/gameplay.jpg)
+
+- **[Zero District — Shells 3D](https://iamsonic.net/2026/mini-games/shells-3d/play.html)** — 자동 사격, 이동을 통한 회피, 경험치 수집과 업그레이드 선택으로 3분간의 도시 포위전에서 살아남으세요.
+  - 제작자: [Sonic的奇思妙想](https://x.com/sonic0828)
+  - 플랫폼: 브라우저. WASD 또는 드래그로 이동하며 자동으로 조준합니다. 로그인이나 다운로드가 필요 없습니다.
+  - GPT-6 Astra: [제작자 설명](https://x.com/sonic0828/status/2097601232877781344) — 제작자는 모음 공개 글에서 GPT-6 Astra를 명시하고 별도 답글에 이 3D 생존 게임을 연결했습니다. [검증 기록](assets/screenshots/zero-district-shells-3d/SOURCE.md).
+  - 자료: [제작자의 공개 링크](https://x.com/sonic0828/status/2097602391122264310)
+  - 미리보기: ![도시 거리에서 주변 적에게 자동 사격하는 생존자, 처치 수 14와 남은 시간 166초 표시.](assets/screenshots/zero-district-shells-3d/gameplay.jpg)
+
+- **[ASCII DISTRICT](https://ascii-district.vercel.app/)** — ASCII 문자로 그려진 1인칭 경기장에서 달리기, 점프와 슬라이딩을 활용해 밀려오는 컴퓨터 바이러스 적들과 싸우세요.
+  - 제작자: [Acker Code](https://x.com/acker_code)
+  - 플랫폼: 데스크톱 브라우저. 키보드와 마우스 조작, 로그인 불필요. 경기장을 클릭하면 마우스가 고정되고 Esc로 해제됩니다.
+  - GPT-6 Astra: [제작자 설명](https://x.com/acker_code/status/2097542957070975286) — 제작자는 이 ASCII 아트 슈팅 게임을 만들 때 Codex와 GPT-6 Astra를 사용했다고 명시합니다. [검증 기록](assets/screenshots/ascii-district/SOURCE.md).
+  - 미리보기: ![바이러스 적들이 다가오는 ASCII 안뜰과 발사 후 탄약 29발이 표시된 소총 HUD.](assets/screenshots/ascii-district/gameplay.jpg)
+
+- **[Aura Farming: Unbothered](https://www.aigameshare.com/games/aura-farming-game)** — 용선 위에서 춤추는 카피바라의 균형을 잡고 파도에 맞춰 몸을 기울이며 40초 안에 여섯 가지 동작을 완료하세요.
+  - 제작자: [nilni / @nil](https://www.aigameshare.com/profile/nil)
+  - 플랫폼: 데스크톱 브라우저. 로그인 없이 무료로 플레이할 수 있습니다. Play를 클릭하며 계정 기능은 선택 사항입니다.
+  - GPT-6 Astra: [제작자 등록 페이지](https://www.aigameshare.com/games/aura-farming-game) — 제작자는 게임 제작에 GPT-6 Astra와 Codex를 사용했으며 Blender, Three.js, ImageGen, WebAudio도 함께 명시합니다. [검증 기록](assets/screenshots/aura-farming/SOURCE.md).
+  - 미리보기: ![용선 위에서 춤추는 카피바라와 기울이기·버티기 조작, 여섯 동작 도전 HUD.](assets/screenshots/aura-farming/gameplay.jpg)
+
 <a id="puzzles"></a>
 
 ### 퍼즐 및 두뇌 게임
@@ -135,6 +199,25 @@
   - 모델 참여: [제작 기록](works/sunjing-puzzles/CREATION.md) — Codex에서 게임 설계, 절차적 3D 그래픽, 규칙, 솔버와 테스트를 여러 차례 개발했습니다. GPT-6 Astra의 구체적인 사용 여부는 제작자 확인을 기다리고 있습니다(초안 제출).
   - 개발 자료: [소스 코드 및 실행 안내](works/sunjing-puzzles/README.md) · [요구사항 기록](works/sunjing-puzzles/PROMPTS.md) · 사용 기술: React, Vinext/Vite, Three.js.
   - 미리보기: ![초록색 3D 작업대 위에 놓인 Sunjing의 6개 부품 나무 퍼즐과 부품 번호, 빼내기 조작부.](assets/screenshots/sunjing-puzzles/gameplay.jpg)
+
+- **[CityMaker](https://citymaker.0to1app.com)** — 4×4 도시 블록에서 즐기는 2048 퍼즐입니다. 같은 건물을 합쳐 도시마다 전통 가옥부터 상징적인 스카이라인까지 11단계 건축물을 완성하세요. 12개 도시를 제공하며 시점을 한 번에 45°씩 회전할 수 있습니다.
+  - 제작자: [Derek Wang](https://github.com/derek-wangpch)
+  - 플랫폼: WebGL을 지원하는 데스크톱·모바일 브라우저. 영어, 중국어 간체·번체를 지원합니다. 무료이며 로그인이나 API 키가 필요 없습니다. 진행 상황은 현재 브라우저에 도시별로 저장되며 iOS 홈 화면에 설치할 수 있습니다.
+  - GPT-6 Astra: [제작 기록](https://github.com/derek-wangpch/OpenCityMaker/blob/master/docs/CREATION.md) — 제작자는 여러 시점의 참고 자료 조사, 실루엣을 우선한 건물 덩어리 구성, 스크린샷 검증을 반복하며 GPT-6 Astra로 건물 모델 132개의 절차적 지오메트리를 모두 생성했다고 설명합니다. 한 번의 프롬프트로 끝낸 테스트는 아닙니다.
+  - 자료: [소스 코드 및 설정](https://github.com/derek-wangpch/OpenCityMaker) · [검증 기록](https://github.com/derek-wangpch/OpenCityMaker/blob/master/QA.md) · 사용 기술: React, TypeScript, Vite, Three.js. 건물 모델 132개는 모두 독자적인 절차적 지오메트리입니다.
+  - 미리보기: ![4×4 격자의 로우폴리 3D 건물로 이루어진 CityMaker의 홍콩 보드, 점수와 도시 선택 목록 및 회전 조작.](assets/screenshots/citymaker/gameplay.png)
+
+- **[Bonkshot](https://bonkshot.com/)** — 새총을 당겨 작은 Bonker들을 나무 지지대로 발사하고 구조물을 무너뜨려 목표를 제거하세요.
+  - 제작자: [edmund5](https://x.com/edmund5)
+  - 플랫폼: 브라우저. 드래그로 조준하고 놓아서 발사합니다. 로그인 없이 플레이할 수 있으며 Google 로그인은 선택 사항입니다.
+  - GPT-6 Astra: [제작자 설명](https://x.com/edmund5/status/2097603093819261002) — 제작자는 게임에 GPT-6 Astra와 Three.js를 사용했으며 배경 음악은 Suno로 만들었다고 밝힙니다. [검증 기록](assets/screenshots/bonkshot/SOURCE.md).
+  - 미리보기: ![첫 Grasslands 퍼즐에서 발사 후 일부 무너진 나무 탑, 남은 목표 하나와 2,200점 표시.](assets/screenshots/bonkshot/gameplay.jpg)
+
+- **[Greenhouse Escape Room: The Last Seed](https://www.aigameshare.com/games/greenhouse-escape-room)** — 봉인된 온실을 탐험하고 구리 수도관을 복구하며 식물과 반사광을 배치해 마지막 씨앗을 구하세요.
+  - 제작자: [nilni / @nil](https://www.aigameshare.com/profile/nil)
+  - 플랫폼: 브라우저. Play를 클릭한 뒤 Begin을 선택합니다. 무료이며 로그인은 필요 없습니다. 영어와 중국어 조작 UI를 제공합니다.
+  - GPT-6 Astra: [제작자 등록 페이지](https://www.aigameshare.com/games/greenhouse-escape-room) — 제작자는 GPT-6 Astra와 Codex를 개발 도구로 명시했으며 ImageGen과 WebAudio도 사용했습니다. [검증 기록](assets/screenshots/greenhouse-escape-room/SOURCE.md).
+  - 미리보기: ![온실 탈출 게임의 Waterworks 방, 아홉 칸 배관 장치와 타이머 및 인벤토리.](assets/screenshots/greenhouse-escape-room/gameplay.jpg)
 
 <a id="strategy-simulation"></a>
 
@@ -227,6 +310,24 @@
   - 개발 자료: [GitHub](https://github.com/LucasMarquesShiva/the-free-game)
   - 미리보기: ![The Free Game](assets/screenshots/the-free-game/gameplay.jpg)
 
+- **[AGI of Empires — The Compute Wars](https://agiofempires.com/)** — 자금과 GPU를 모으고 데이터센터와 군대를 건설해 경쟁 AI 연구소보다 먼저 ASI에 도달하거나 상대 본부를 파괴하세요.
+  - 제작자: [timour kosters](https://x.com/timourxyz)
+  - 플랫폼: 데스크톱 브라우저의 무료 풍자 실시간 전략 게임. 로그인 없이 초반 컴퓨터 상대전과 자원 수집을 확인했습니다.
+  - GPT-6 Astra: [X](https://x.com/timourxyz/status/2096662786692776293) — 제작자는 Age of Empires에서 영감을 받은 이 게임을 Astra로 이틀 동안 개발했다고 설명합니다. [검증 기록](assets/screenshots/agi-of-empires/SOURCE.md).
+  - 미리보기: ![AGI of Empires의 전장과 자원 수치, 본부.](assets/screenshots/agi-of-empires/gameplay.jpg)
+
+- **[Atlas Go](https://atlas-go.borisxp.chatgpt.site/)** — 도로망과 독특한 그래프 보드에서 바둑을 즐기세요. 한 기기에서 번갈아 두는 방식과 친구 대국 옵션을 제공합니다.
+  - 제작자: [Boris Power](https://x.com/BorisMPower)
+  - 플랫폼: 브라우저. 로그인 없이 로컬 보드가 열렸습니다. 온라인 친구 대국은 테스트하지 않았습니다.
+  - GPT-6 Astra: [X](https://x.com/BorisMPower/status/2096784808399843582) — 제작자는 임의의 그래프에서 즐기는 이 멀티플레이 바둑을 Astra에 프롬프트 하나만 입력해 만들었다고 설명합니다. [검증 기록](assets/screenshots/atlas-go/SOURCE.md).
+  - 미리보기: ![Atlas Go의 벌집 모양 그래프 보드에 놓인 흑돌과 백돌.](assets/screenshots/atlas-go/gameplay.jpg)
+
+- **[Ironwood — The Art of Industry](https://ironwood.sparkles.dev/)** — 원자재를 모으고 기계에 전력을 공급하며 컨베이어 벨트를 연결해 빈터를 가동 중인 공장으로 바꾸세요.
+  - 제작자: [Dan](https://x.com/aidaniil)
+  - 플랫폼: 데스크톱 브라우저. 게스트 튜토리얼은 로그인 없이 열리지만 진행 상황을 저장하려면 로그인해야 합니다. 멀티플레이는 독립적으로 테스트하지 않았습니다.
+  - GPT-6 Astra: [X](https://x.com/aidaniil/status/2096426970930106530) — 제작자는 형제와 함께 Satisfactory와 Besiege에서 영감을 받아 Astra, Blender MCP, Cloudflare Durable Objects로 만들었다고 설명합니다. [검증 기록](assets/screenshots/ironwood/SOURCE.md).
+  - 미리보기: ![Ironwood의 공장 기계, 컨베이어 벨트와 자원 관리 튜토리얼.](assets/screenshots/ironwood/gameplay.jpg)
+
 - **[DUST FRONT](https://dust-front.mustafaakin.dev/)** — 기지 건설, 거점 점령, 지상군과 공군 지휘를 즐기는 싱글 플레이 RTS입니다.
   - 제작자: [Mustafa Akın](https://x.com/mustafaakin)
   - 플랫폼: 데스크톱 브라우저, 키보드와 마우스 사용. 로그인 불필요.
@@ -239,6 +340,18 @@
   - GPT-6 Astra: [X](https://x.com/HDLhN783wtLkpPR/status/2097321360641122393) — 제작자는 링크된 게시물에서 이 RTS를 만드는 데 “GPT Astra”를 사용했다고 밝혔습니다. 정확한 모델 버전과 상세 개발 과정은 명시하지 않았습니다.
   - 참고 자료: [제출 글](https://github.com/MartinDelophy/awesome-gpt-6-astra/issues/66) · [검증 기록(영어)](assets/screenshots/frontline-command/SOURCE.md)
   - 미리보기: ![Frontline Command의 실제 대전 화면: 기지, 선택된 탱크 3대, 발전소 배치. v0.8, 2026-09-09 촬영.](assets/screenshots/frontline-command/gameplay.jpg)
+
+- **[Coin Pusher Roguelite: Mintfall](https://www.aigameshare.com/games/coin-pusher-roguelite-mintfall)** — 3D 코인 푸셔를 조준하고 특수 코인과 유물을 조합해 제한된 투입 횟수 안에 목표 점수를 달성하며 여섯 라운드를 통과하세요.
+  - 제작자: [nilni / @nil](https://www.aigameshare.com/profile/nil)
+  - 플랫폼: 브라우저. Play를 클릭하면 무료로 로그인 없이 시작합니다. 계정을 통한 저장은 선택 사항입니다.
+  - GPT-6 Astra: [제작자 등록 페이지](https://www.aigameshare.com/games/coin-pusher-roguelite-mintfall) — 제작자는 GPT-6 Astra, GPT-5.6 Sol과 Codex를 함께 명시하지만 등록 페이지에서는 각각의 기여를 구분하지 않습니다. [검증 기록](assets/screenshots/mintfall/SOURCE.md).
+  - 미리보기: ![Mintfall의 1라운드 3D 코인 트레이, 33점과 투입 횟수 44, 특수 코인 조작 UI.](assets/screenshots/mintfall/gameplay.jpg)
+
+- **[Westward — The Oregon Trail](https://biswaz.me/westward/)** — 마차 원정대를 서쪽으로 이끌며 식량 배급, 수리와 사냥을 관리하고 Oregon Trail을 따라 결정을 내리세요.
+  - 제작자: [Biswas](https://x.com/bis_waz)
+  - 플랫폼: 데스크톱 브라우저. 제공된 가상의 원정대로 시작하며 로그인이나 설치가 필요 없습니다.
+  - GPT-6 Astra: [X](https://x.com/bis_waz/status/2098023593468907747) — Biswas는 GPT-6 Astra로 The Oregon Trail의 현대적인 3D 버전을 만들었다고 밝히며 플레이 가능한 게임을 연결했습니다. [검증 기록](assets/screenshots/westward/SOURCE.md).
+  - 미리보기: ![Kansas River로 향하는 마차와 소, 이동 거리 25마일과 원정 보급품 패널.](assets/screenshots/westward/gameplay.jpg)
 
 <a id="rpg-adventures"></a>
 
@@ -276,6 +389,63 @@
   - 플랫폼: 데스크톱 브라우저에서 로그인·결제 없이 열었습니다. 모바일은 미검증입니다.
   - GPT-6 Astra: [X](https://x.com/emollick/status/2096047660662722620) — 제작자는 이 프로젝트 개발에 Astra를 사용했다고 밝혔습니다. [검증 기록 (영어)](assets/screenshots/zork/SOURCE.md).
   - 미리보기: ![Zork · The Great Underground Empire](assets/screenshots/zork/gameplay.jpg)
+
+- **[The Simpsons: Hit & Run — Browser Recreation](https://vheissu.github.io/hit-and-run-web/)** — 미션, 교통과 경찰 추격이 있는 비공식 브라우저 재현작에서 걸어서 또는 자동차로 Springfield를 탐험하세요.
+  - 제작자: [Dwayne](https://x.com/CtrlAltDwayne)
+  - 플랫폼: 데스크톱 브라우저. 대용량 초기 에셋을 불러온 후 로그인 없이 첫 미션이 열렸습니다. 전체 캠페인 완료는 테스트하지 않았습니다.
+  - GPT-6 Astra: [X](https://x.com/CtrlAltDwayne/status/2096872309936287887) — 제작자는 GPT-6 Astra로 게임을 웹용으로 재구현했다고 설명하며, 저장소에는 로딩 작업에 Claude의 도움을 받았다는 내용도 있습니다. 원작 게임 에셋의 권리는 원 권리자에게 있습니다. [검증 기록](assets/screenshots/hit-and-run-web/SOURCE.md).
+  - 자료: [소스 코드 및 설정](https://github.com/Vheissu/hit-and-run-web)
+  - 미리보기: ![Springfield의 Homer와 첫 미션 목표 및 미니맵.](assets/screenshots/hit-and-run-web/gameplay.jpg)
+
+- **[Where the Wind Wanders](https://app.usecrayon.ai/play/a9a3c165-74b3-4ff6-9588-ad97f829ddb5)** — 햇살이 비치는 2.5D 계곡의 길을 따라 거닐며 바람의 편지 세 통을 모으는 조용한 탐험 모험입니다.
+  - 제작자: [Tushar](https://x.com/TusharXo)
+  - 플랫폼: Crayon에서 제공하는 브라우저 게임. 공개 게임 페이지와 내장 플레이어를 확인했습니다.
+  - GPT-6 Astra: [X](https://x.com/TusharXo/status/2096037482739683574) — Tushar는 Astra로 경로와 에셋을 생성했다고 설명하며, 후속 글에서 Astra, Three.js, Crayon을 사용한 플레이 가능한 버전의 공개를 알렸습니다. [검증 기록](assets/screenshots/crayon-adventure/SOURCE.md).
+  - 자료: [제작자 공개 소식](https://x.com/TusharXo/status/2096741535891251261)
+  - 미리보기: ![꽃이 가득한 계곡을 탐험하는 캐릭터와 바람의 편지 목표 표시.](assets/screenshots/crayon-adventure/gameplay.jpg)
+
+- **[ALIBI — The Last Light](https://alibi-blackthorn-manor.vercel.app/)** — 포인트 앤 클릭 살인 미스터리에서 Blackthorn Manor를 조사하고 현장과 단서를 살펴 범인을 밝혀내세요.
+  - 제작자: [Christos Antonopoulos](https://x.com/Christos_antono)
+  - 플랫폼: 브라우저. 로그인 없이 상호작용 가능한 저택 입구가 열렸습니다. 이후 생성되는 장면은 모두 테스트하지 않았습니다.
+  - GPT-6 Astra: [X](https://x.com/Christos_antono/status/2096435122669297892) — 제작자는 이 생성형 추리 게임에 GPT Astra와 H3 Max를 함께 사용했다고 밝힙니다. [검증 기록](assets/screenshots/alibi-blackthorn-manor/SOURCE.md).
+  - 미리보기: ![클릭 가능한 문과 도입부 수사 설명이 표시된 저택 입구.](assets/screenshots/alibi-blackthorn-manor/gameplay.jpg)
+
+- **[Skyward: The Gathering](https://edge-city-skyward-quests.vercel.app/)** — 떠 있는 섬들을 탐험하고 점프와 활공으로 공동체 사이를 이동하며 주민들의 퀘스트를 완료하세요.
+  - 제작자: [timour kosters](https://x.com/timourxyz)
+  - 플랫폼: 데스크톱 브라우저, 키보드와 마우스. 퀘스트 버전의 페이지와 조작 방법을 확인했습니다.
+  - GPT-6 Astra: [X](https://x.com/timourxyz/status/2096379521926840339) — 제작자는 Edge City의 장소들에서 영감을 받아 Astra로 NPC와 퀘스트가 있는 플레이 가능한 3D 게임을 만들었다고 설명합니다. [검증 기록](assets/screenshots/skyward-gathering/SOURCE.md).
+  - 미리보기: ![떠 있는 섬들이 내려다보이는 Skyward 화면과 탐험 및 일지 조작 UI.](assets/screenshots/skyward-gathering/gameplay.jpg)
+
+- **[Anna & Leo · The Starstone Adventure](https://anna-leo-starstone.vercel.app/)** — Anna의 음악 마법과 Leo의 초능력을 번갈아 사용해 멜로디 꽃을 깨우고 Wonder Garden을 탐험하세요.
+  - 제작자: [Dharma Utomo](https://x.com/dharmautomo)
+  - 플랫폼: 브라우저. 로그인 없이 첫 퀘스트가 시작되었습니다. WASD 이동, Space 점프, E 능력, Tab 영웅 전환.
+  - GPT-6 Astra: [X](https://x.com/dharmautomo/status/2096573649235091967) — 제작자는 GPT-6 Astra의 도움으로 이 3D 모험을 만들었다고 설명하며 자녀들이 플레이 테스트하는 영상을 공유합니다. [검증 기록](assets/screenshots/anna-leo-starstone/SOURCE.md).
+  - 미리보기: ![Anna와 Leo의 3D 모험 세계와 퀘스트 UI.](assets/screenshots/anna-leo-starstone/gameplay.jpg)
+
+- **[The Legend of Deller](https://rain-court-js.umodeler-inc-4323.chatgpt.site/)** — Rainmist Haven을 탐험하고 검 연계 공격, 원소 기술과 회피 동작으로 던전을 향해 나아가세요.
+  - 제작자: [UModeler X PicoBerry](https://x.com/UModeler)
+  - 플랫폼: 데스크톱 브라우저. 키보드와 마우스 조작, 로그인 불필요. 초기 3D 에셋 로딩이 끝날 때까지 기다리세요.
+  - GPT-6 Astra: [제작자 설명](https://x.com/UModeler/status/2097792348407099553) — 제작자는 PicoBerry로 에셋을 생성하고 GPT-6 Astra로 이를 활용한 Three.js 액션 RPG를 만들었다고 설명합니다. [검증 기록](assets/screenshots/the-legend-of-deller/SOURCE.md).
+  - 자료: [제작자의 공개 링크](https://x.com/UModeler/status/2097792351129178451)
+  - 미리보기: ![Rainmist Haven의 분수와 시장 가판대 옆에서 회피하는 Deller, 체력·마나와 기술 조작 UI.](assets/screenshots/the-legend-of-deller/gameplay.jpg)
+
+- **[Dungeon of Astra](https://wavedash.com/games/dungeon-of-astra)** — 동료를 모집해 100층 던전을 내려가며 검 공격, 화염구와 동료별 역할을 조합하세요. 한 번 죽으면 되살릴 수 없는 진행 방식을 사용합니다.
+  - 제작자: [tonysuri / @tonysurix](https://x.com/tonysurix)
+  - 플랫폼: Wavedash의 데스크톱 브라우저 게임. 기본 게임은 로그인 없이 시작합니다. 계정 사용과 유료 캐릭터 조기 해금은 선택 사항입니다.
+  - GPT-6 Astra: [제작자 설명](https://x.com/tonysurix/status/2097873333551616355) — 제작자는 이 파티형 던전 탐험 게임을 GPT-6 Astra로 만들었다고 명시합니다. [검증 기록](assets/screenshots/dungeon-of-astra/SOURCE.md).
+  - 미리보기: ![던전 1층에서 화염구를 사용하는 영웅과 고용한 기사, 파티 체력과 미니맵.](assets/screenshots/dungeon-of-astra/gameplay.jpg)
+
+- **[Sunlandia — The Forgotten Shore](https://sunlandia.smallweblab.com/)** — 난파 후 도착한 섬을 1인칭으로 탐험하고 단서를 조사하며 환경 퍼즐을 풀어 등대로 향하세요.
+  - 제작자: [Ramon Linares / Small Web Lab](https://github.com/RamonLinares)
+  - 플랫폼: 데스크톱 브라우저. 섬이 로딩되면 Begin expedition을 선택하세요. 무료이며 계정이나 설치가 필요 없습니다.
+  - GPT-6 Astra: [제작자 개발 일지](https://smallweblab.com/posts/sunlandia/) — 제작자는 GPT-5.6 Sol로 시작해 Fable의 도움을 받았으며 GPT-6 Astra로 게임을 완성했습니다. [검증 기록](assets/screenshots/sunlandia/SOURCE.md).
+  - 미리보기: ![난파선과 부서진 부두, 도움을 찾으라는 목표가 보이는 Sunlandia의 1인칭 해안 화면.](assets/screenshots/sunlandia/gameplay.jpg)
+
+- **[NÁCAR](https://nacar-microcosmo.preda2005.chatgpt.site/)** — 물에 잠긴 달팽이 껍데기 안에서 미생물을 키우고 영양분을 모으며 탐험 중 새로운 신체 부위를 발달시키세요.
+  - 제작자: [Marcio Lima / @Preda2005](https://x.com/Preda2005)
+  - 플랫폼: 브라우저. 로그인 없이 즐기는 무료 베타이며 중국어를 포함한 다섯 가지 UI 언어를 지원합니다.
+  - GPT-6 Astra: [제작자 스레드](https://x.com/Preda2005/status/2097954217180921928) — Marcio는 생물 진화 아이디어를 GPT-6 Astra에 설명한 뒤 연결된 베타 게임으로 개발했다고 말합니다. [검증 기록](assets/screenshots/nacar/SOURCE.md).
+  - 미리보기: ![색색의 영양분 사이에 있는 작은 세포와 생체량, 진화, 인벤토리 및 탐험한 수역 관련 UI.](assets/screenshots/nacar/gameplay.jpg)
 
 <a id="platformers-racing"></a>
 
@@ -341,6 +511,31 @@
   - GPT-6 Astra: [Issue #51](https://github.com/MartinDelophy/awesome-gpt-6-astra/issues/51) — 제작자 설명: 첫 버전은 Qwen3.8 Max, 두 번째는 Astra로 전면 재구축.
   - 미리보기: ![疾风赛道 / Kart Racing（跑跑卡丁车）](https://github.com/user-attachments/assets/015e0ca1-7032-4d0e-9391-ad3f40d84227)
 
+- **[TIDAL RUSH — Paradise GP](https://tidal-rush-paradise-gp.skirano.chatgpt.site/)** — 열대 카트 코스에서 드리프트와 아이템을 활용해 세 바퀴 동안 일곱 명의 경쟁자와 레이스를 펼치세요.
+  - 제작자: [Pietro Schirano](https://x.com/skirano)
+  - 플랫폼: 브라우저. 로그인 없이 세 바퀴 레이스가 시작되었습니다. 키보드로 운전, 드리프트와 아이템을 조작하며 화면 터치 버튼도 있습니다.
+  - GPT-6 Astra: [모델 사용 근거](https://openai.com/index/gpt-6-astra/) — OpenAI의 Astra 출시 페이지가 이 인터랙티브 카트 게임을 연결하고 제작자로 Pietro Schirano를 명시합니다. X 소개 글은 제작자 본인의 글이 아닌 커뮤니티 공유 게시물입니다. [검증 기록](assets/screenshots/tidal-rush/SOURCE.md).
+  - 자료: [X 소개 게시물](https://x.com/alexgetmancom/status/2095598460921614825)
+  - 미리보기: ![열대 카트 트랙과 순위 및 드리프트 조작 UI가 보이는 Tidal Rush.](assets/screenshots/tidal-rush/gameplay.jpg)
+
+- **[LUNA — Crimson Requiem / 紅月のレクイエム](https://luna-crimson-requiem.ponsuke.chatgpt.site/)** — 고딕풍 픽셀 아트 스테이지에서 점프하며 적을 베거나 밟고 소환 공격도 사용하는 짧은 횡스크롤 모험입니다.
+  - 제작자: [音羽ぽんすけ](https://x.com/ponsuke_otowa)
+  - 플랫폼: 브라우저, 일본어 UI. 키보드 조작을 제공하며 제작자는 스마트폰 지원도 알렸습니다. 한 스테이지가 공개되어 있습니다.
+  - GPT-6 Astra: [X](https://x.com/ponsuke_otowa/status/2096531744933425299) — 제작자는 Astra로 약 25분 동안 개발하고 걷기 애니메이션을 한 번 수정했다고 설명합니다. 음악은 별도로 Suno 제작임을 명시했습니다. [검증 기록](assets/screenshots/luna-crimson-requiem/SOURCE.md).
+  - 미리보기: ![붉은 달이 뜬 고딕풍 거리에서 싸우는 LUNA와 체력 및 소환 게이지.](assets/screenshots/luna-crimson-requiem/gameplay.jpg)
+
+- **[Strange Orbit](https://app.usecrayon.ai/play/47df78e2-1410-45d1-833c-196e1161c0b8)** — 우주비행사 사이클 선수로 행성 고리를 달리며 별가루를 모으고 상대 뒤에서 공기 저항을 줄여 부스트로 Orbital Cup을 돌파하세요.
+  - 제작자: [Crayon](https://x.com/usecrayon)
+  - 플랫폼: Crayon의 브라우저 게임. 키보드 조작과 문서에 기재된 터치 조작을 제공합니다. 공개 페이지에는 레이스, 타임 트라이얼과 끝없는 탐험 모드가 있습니다.
+  - GPT-6 Astra: [X](https://x.com/usecrayon/status/2097468975995302167) — Crayon은 이 우주 자전거 게임에 GPT-6 Astra, Crayon Pro와 Three.js를 사용했다고 밝힙니다. [검증 기록](assets/screenshots/crayon-space-bike/SOURCE.md).
+  - 미리보기: ![행성 고리에서 경주하는 우주비행사 사이클 선수들과 바퀴 수, 순위 및 별가루 표시.](assets/screenshots/crayon-space-bike/gameplay.jpg)
+
+- **[One More Vine — Into the Wild](https://onemorevine.bennash.dev/)** — 네 개의 정글 레벨을 달리고 점프하고 덩굴을 타며 보물을 모으고 악어를 피하면서 기록을 단축하세요.
+  - 제작자: [Ben Nash](https://x.com/bennash)
+  - 플랫폼: 브라우저. 키보드와 화면 이동 조작을 제공하며, 로그인 없이 첫 레벨과 안내가 로딩되었습니다.
+  - GPT-6 Astra: [X](https://x.com/bennash/status/2096282758930645170) — 제작자는 Pitfall에서 영감을 받아 GPT-6 Astra로 제작한 4개 레벨의 게임이라고 명시합니다. [검증 기록](assets/screenshots/one-more-vine/SOURCE.md).
+  - 미리보기: ![매달린 덩굴, 보물, 구덩이와 악어가 있는 정글 플랫폼 레벨.](assets/screenshots/one-more-vine/gameplay.jpg)
+
 - **[混合马里奥Ⅱ · 忍者龙剑传 × 坦克大战 / Mario Mix II](https://aha-xiaoq.github.io/games/mario-mix-2/play.html)** — 닌자 가이덴의 류 하야부사와 배틀 시티의 탱크로 마리오의 지하 스테이지 1-2에 도전합니다. 류는 횡스크롤 점프·벽 타기·전투를, 탱크는 탑다운 전투를 즐길 수 있으며, 닌자에서 탱크로 이어지는 릴레이로 공주를 구할 수도 있습니다.
   - 제작자: [在下_小Q（Aha-xiaoQ）](https://github.com/Aha-xiaoQ)
   - 플랫폼: 데스크톱 브라우저, 중국어 UI, 키보드 권장. 무료이며 로그인이나 설치가 필요 없습니다.
@@ -349,6 +544,37 @@
   - 소재 안내: 비공식 팬 게임입니다. 기존 캐릭터·이미지·음악의 권리는 각 권리자에게 있으며, 소재 출처는 원본 게임 페이지에 안내되어 있습니다.
   - 미리보기: ![Mario Mix II — 제작자가 제공한 영상 표지이며 실제 플레이 캡처가 아닙니다.](https://aha-xiaoq.github.io/games/mario-mix-2/cover.jpg)
   - 스크린샷: ![Mario Mix II의 탱크가 1-2 스테이지 입구에서 발사하는 모습. 버전 1.0, 2026-09-09 촬영.](assets/screenshots/mario-mix-2/gameplay.jpg)
+
+- **[Bengaluru ORR Rush](https://orr-rush-bengaluru.ravitheja.chatgpt.site/)** — Bengaluru의 도로를 질주하며 포트홀과 배달 오토바이를 피하고 부스트나 옆으로 휘두르는 동작으로 공간을 확보하세요.
+  - 제작자: [Ravi Theja](https://x.com/ravithejads)
+  - 플랫폼: 데스크톱 브라우저. 키보드 조작과 선택 가능한 자동 가속 기능이 있으며 로그인은 필요 없습니다.
+  - GPT-6 Astra: [제작자 설명](https://x.com/ravithejads/status/2097181044625887392) — 제작자는 Bengaluru 도로 레이싱 게임을 GPT-6 Astra로 만들었다고 밝힙니다. [검증 기록](assets/screenshots/bengaluru-orr-rush/SOURCE.md).
+  - 미리보기: ![Bengaluru 도로의 파란 플레이어 자동차와 순위, 속도, 타이머 및 조작 안내.](assets/screenshots/bengaluru-orr-rush/gameplay.jpg)
+
+- **[SKICROSS — Alpine Downhill](https://iamsonic.net/2026/mini-games/skicross.html)** — 세 명의 스키 선수와 산을 내려가며 경쟁하고 게이트와 장애물을 통과해 눈사태보다 앞서가세요.
+  - 제작자: [Sonic的奇思妙想](https://x.com/sonic0828)
+  - 플랫폼: 데스크톱 브라우저. A/D 방향 조절, Space 점프, Shift 부스트. 로그인이나 다운로드가 필요 없습니다.
+  - GPT-6 Astra: [제작자 설명](https://x.com/sonic0828/status/2097601232877781344) — 제작자는 미니게임 모음을 GPT-6 Astra로 만들었다고 밝히고 별도 답글에 이 스키 게임을 공개했습니다. [검증 기록](assets/screenshots/skicross/SOURCE.md).
+  - 자료: [제작자의 공개 링크](https://x.com/sonic0828/status/2097601732297814300)
+  - 미리보기: ![눈 덮인 코스의 스키 선수 네 명, 게이트 보너스와 순위·속도·눈사태 거리 표시.](assets/screenshots/skicross/gameplay.jpg)
+
+- **[Itsy Bitsy Spider · One More Climb](https://game-bench.piccini.app/games/gpt-6-astra/)** — 이끼 낀 벽을 기어오르고 파리를 잡아 붙잡는 힘을 회복하며, 비에 쓸려 내려가기 전에 피난 구멍에 숨으세요.
+  - 제작자: [Luiz Piccini](https://piccini.app/)
+  - 플랫폼: 브라우저. 무료이며 로그인은 필요 없습니다. WASD 또는 화면 조이스틱을 사용합니다.
+  - GPT-6 Astra: [제작자의 Game Bench](https://game-bench.piccini.app/) — Game Bench는 공통 게임 기획을 바탕으로 만든 이 공개 결과물을 GPT-6 Astra canary, high, 날짜 2026-09-05로 표시합니다. [검증 기록](assets/screenshots/itsy-bitsy-spider/SOURCE.md).
+  - 미리보기: ![이끼 낀 벽돌 벽의 2미터 높이를 오르는 거미와 붙잡는 힘, 파리, 피난처 및 이동 조이스틱.](assets/screenshots/itsy-bitsy-spider/gameplay.jpg)
+
+- **[Desi Mayhem](https://desimayhem.com/)** — 인도 도시의 교통 속에서 오토바이를 몰며 버스와 오토릭샤 사이를 누비고 발차기, 펀치와 부스트를 사용하세요.
+  - 제작자: [Kishore](https://x.com/GetKishore)
+  - 플랫폼: 데스크톱 브라우저. 무료이며 계정은 필요 없습니다. 첫 주행 전에 자동 생성된 라이더 별명을 수락하거나 수정하세요.
+  - GPT-6 Astra: [제작자 개발 스레드](https://x.com/GetKishore/status/2097906401159102811) — Kishore는 거리 참고 자료를 활용하고 교통, 충돌과 라이더 전투를 반복 테스트하며 Astra로 만든 3D 게임을 개선했다고 설명합니다. [검증 기록](assets/screenshots/desi-mayhem/SOURCE.md).
+  - 미리보기: ![Chennai의 오토바이 레이스, 플레이어 라이더와 시내 교통, 미니맵, 순위 및 레이스 타이머.](assets/screenshots/desi-mayhem/gameplay.jpg)
+
+- **[Cosmic Tides](https://app.usecrayon.ai/play/362ae1e7-29bd-4fbc-9103-00649265d942)** — 은하의 바다 위로 기체를 몰아 빛나는 게이트를 따라가세요. 두 바퀴 레이스와 끝없는 표류 중에서 선택할 수 있습니다.
+  - 제작자: [Aniket J](https://x.com/aniketjart)
+  - 플랫폼: 브라우저. 3D 에셋 로딩을 기다린 뒤 Ride the current를 선택합니다. 무료이며 로그인은 필요 없습니다.
+  - GPT-6 Astra: [X](https://x.com/aniketjart/status/2098207146647433534) — Aniket은 게임에 GPT-6 Astra, Blender MCP와 Crayon을 사용했다고 밝히며, 추가 게임플레이 개선을 계획한 실험작이라고 설명합니다. [검증 기록](assets/screenshots/cosmic-tides/SOURCE.md).
+  - 미리보기: ![은하의 바다 위에서 빛나는 게이트로 다가가는 Cosmic Tides 레이스와 바퀴 수 및 속도 표시.](assets/screenshots/cosmic-tides/gameplay.jpg)
 
 <a id="experimental-multiplayer"></a>
 
@@ -394,6 +620,12 @@
   - 플랫폼: 브라우저, 무료, 로그인 불필요. 제작자는 VPN/프록시가 필요할 수 있다고 안내합니다. 싱글 시작 확인, 멀티플레이 미검증.
   - GPT-6 Astra: [Issue #52](https://github.com/MartinDelophy/awesome-gpt-6-astra/issues/52) — 제작자 설명: 첫 버전은 GPT-6 Astra Pro, 후속 개선은 Codex의 GPT-6 Astra.
   - 미리보기: ![泡泡坦克大作战联机版 / Toon Tank Arena](https://github.com/user-attachments/assets/713d44f3-a77c-452c-ba6d-1231882dc670)
+
+- **[Above the Rooftops](https://app.usecrayon.ai/play/d09bb865-2259-42e2-86cc-fb609a9d6f28)** — 연을 꾸미고 도시 지붕 위로 날리며 줄의 장력을 조절하세요. 자유 비행과 제한 시간 내 하늘의 빛을 모으는 도전을 즐길 수 있습니다.
+  - 제작자: [Tushar / @TusharXo](https://x.com/TusharXo)
+  - 플랫폼: 브라우저. 캐릭터를 고르고 옥상에 들어가 Fly를 선택하세요. 무료이며 로그인은 필요 없습니다.
+  - GPT-6 Astra: [X](https://x.com/TusharXo/status/2098156783181467801) — Tushar는 이 Three.js 연날리기 게임에 GPT-6 Astra와 Crayon을 사용했다고 명시하며 시각 요소에는 Images 2.5를 언급합니다. [검증 기록](assets/screenshots/above-the-rooftops/SOURCE.md).
+  - 미리보기: ![도시 위의 연날리기 도전, 높이와 줄 장력, 하늘의 빛 수집 진행도 및 방향 조작 UI.](assets/screenshots/above-the-rooftops/gameplay.jpg)
 
 ## 각 항목에 담는 정보
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -4,7 +4,7 @@
 
 # Awesome GPT-6 Astra
 
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](CONTRIBUTING.md) [![LINUX DO](https://img.shields.io/badge/LINUX%20DO-Community-f0b73f?style=flat-square)](https://linux.do/) [![Cases: 49](https://img.shields.io/badge/Cases-49-58a6ff?style=flat-square)](https://astragames.aigccreative.com/)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](CONTRIBUTING.md) [![LINUX DO](https://img.shields.io/badge/LINUX%20DO-Community-f0b73f?style=flat-square)](https://linux.do/) [![Cases: 86](https://img.shields.io/badge/Cases-86-58a6ff?style=flat-square)](https://astragames.aigccreative.com/)
 
 **Uma coleção de jogos interessantes feitos com GPT-6 Astra.**
 
@@ -22,7 +22,7 @@ Esta página é uma tradução do [README em inglês](README.md). Consulte o ori
 
 ## Comece por aqui
 
-Explore **49 jogos e projetos interativos**: estratégia territorial dos Três Reinos, quebra-cabeças de madeira com encaixes e peças deslizantes, fusão de frutas deformáveis, voo com um toque, combates em tapete mágico, defesa de uma ilha com uma rede elétrica, sobrevivência na natureza, pesca submarina, gestão de um restaurante de sushi e cultivo em uma ilha, corridas de kart no Bay Circuit, ciclismo pela costa com um pelicano, brinquedos de mesa adaptados para 3D e Orbital Garden. Clique em um título para jogar diretamente no navegador.
+Explore **86 jogos e projetos interativos**: estratégia territorial dos Três Reinos, quebra-cabeças de madeira com encaixes e peças deslizantes, fusão de frutas deformáveis, 2048 de construção de cidades com geração procedural, voo com um toque, combates em tapete mágico, um jogo de tiro com chuva de balas e cinco fases, defesa de uma ilha com uma rede elétrica, sobrevivência na natureza, pesca submarina, gestão de um restaurante de sushi e cultivo em uma ilha, corridas de kart no Bay Circuit, ciclismo pela costa com um pelicano, brinquedos de mesa adaptados para 3D, decoração de casas em 3D e Orbital Garden. Clique em um título para jogar diretamente no navegador.
 
 Catálogo atualizado: **2026-09-12**. O uso do modelo é informado com base nas declarações dos criadores ou responsáveis pelas submissões; detalhes não confirmados são sinalizados em cada entrada. Esta data registra a manutenção do catálogo, não um novo teste de todos os jogos.
 
@@ -110,6 +110,70 @@ Jogos de tiro, luta, sobrevivência, ritmo e qualquer experiência que dê vonta
   - GPT-6 Astra: [X](https://x.com/jumperz/status/2096600055301984738) — O autor informa ter usado Astra no desenvolvimento deste projeto. [Notas de verificação (inglês)](assets/screenshots/cinderfall/SOURCE.md).
   - Prévia: ![Cinderfall · Fire, Shadow & Steel](assets/screenshots/cinderfall/gameplay.jpg)
 
+- **[Oz Breakdance](https://satriodewantono.com/breakdance/)** — Arraste os membros de um dançarino com física ragdoll até os alvos correspondentes para marcar pontos e prolongar uma rodada cronometrada de breaking.
+  - Criador: [Satrio](https://x.com/satrio_d)
+  - Plataforma: Navegador de computador, controle pelo mouse; uma rodada cronometrada foi iniciada sem login.
+  - GPT-6 Astra: [X](https://x.com/satrio_d/status/2096022866097758500) — O criador afirma que Astra melhorou seu jogo de breakdance existente e sua apresentação. [Notas de verificação](assets/screenshots/breakdance/SOURCE.md).
+  - Prévia: ![Um dançarino ragdoll tenta alcançar um alvo com o pé na arena de breakdance cronometrada.](assets/screenshots/breakdance/gameplay.jpg)
+
+- **[Astral War](https://astralwar.io/)** — FPS de navegador com tema da Segunda Guerra Mundial, visuais de soldados e zumbis, conjuntos de armas, treino contra bots e opções de sala.
+  - Criador: [Rishi](https://x.com/0xRishi)
+  - Plataforma: Navegador de computador, teclado e mouse; treino contra bots iniciado sem login. Multijogador e controle não foram testados.
+  - GPT-6 Astra: [X](https://x.com/0xRishi/status/2096079660605997264) — Rishi relata ter criado Astral War com Astra, Three.js, Meshy e ElevenLabs. O site atual também credita Vesper; veja a nota de atribuição. [Notas de verificação](assets/screenshots/astral-war/SOURCE.md).
+  - Prévia: ![Combate de Astral War com arma e controles do campo de batalha.](assets/screenshots/astral-war/gameplay.jpg)
+
+- **[FLOP CLUB](https://bubucn.com/ai-model-evals/flop-club/game/index.html)** — Mergulhe de três alturas, faça mortais e giros e mire em um aro flutuante para melhorar a pontuação de entrada na água.
+  - Criador: [BubuAi](https://x.com/BubuStd)
+  - Plataforma: Navegador; o jogo independente inicia sem login nem download. Um mergulho foi iniciado na verificação de 2026-09-09; teclado e controles de toque documentados.
+  - GPT-6 Astra: [X](https://x.com/BubuStd/status/2096402783805354091) — O criador relata uma implementação com Astra Pro e Three.js a partir de um único prompt. [Notas de verificação](assets/screenshots/flop-club/SOURCE.md).
+  - Recursos: [Apresentação do projeto](https://bubucn.com/zh/ai-model-evals/flop-club)
+  - Prévia: ![Um mergulhador na plataforma alta sobre o aro-alvo e os controles de entrada na água.](assets/screenshots/flop-club/gameplay.jpg)
+
+- **[Vector Dive — Beyond the Signal](https://vector-dive.openai.chatgpt.site/)** — Pilote por circuitos de neon em aramado que aceleram a cada volta, usando impulsos e mudanças de fase no momento certo para sobreviver.
+  - Criador: [Thomas Ricouard](https://x.com/Dimillian)
+  - Plataforma: Navegador de computador; voo com pontuação iniciado sem login. WASD para voar, Espaço para impulsionar e Shift para mudar de fase.
+  - GPT-6 Astra: [X](https://x.com/Dimillian/status/2097188900888322323) — O criador afirma que Astra fez o jogo e a música a partir de uma proposta visual neon/synthwave e arte conceitual. [Notas de verificação](assets/screenshots/vector-dive/SOURCE.md).
+  - Prévia: ![Percurso de neon de Vector Dive com nave e indicadores de jogo.](assets/screenshots/vector-dive/gameplay.jpg)
+
+- **[Harbor Skirmish](https://gpt6astra-game.vercel.app/)** — Defenda uma cidade litorânea de ondas de coelhos bagunceiros com três armas, rotas pelos telhados, arrancadas e um gancho.
+  - Criador: [OpenDesign](https://x.com/OpenDesignHQ)
+  - Plataforma: Navegador de computador; teclado e mouse, sem login nem download.
+  - GPT-6 Astra: [Declaração do criador](https://x.com/OpenDesignHQ/status/2097635757917983223) — OpenDesign identifica este jogo de Three.js como a versão GPT-6 Astra em sua comparação de dois modelos. [Notas de verificação](assets/screenshots/harbor-skirmish/SOURCE.md).
+  - Prévia: ![Visão de rifle em primeira pessoa em Seabreeze, coelhos se aproximando, contador de ondas e controles de armas.](assets/screenshots/harbor-skirmish/gameplay.jpg)
+
+- **[UNDERGROUND — Underground Boxing](https://iamsonic.net/2026/mini-games/underground-boxing.html)** — Lute boxe em três rounds cronometrados num ringue subterrâneo 3D, equilibrando socos, bloqueios, esquivas e resistência.
+  - Criador: [Sonic的奇思妙想](https://x.com/sonic0828)
+  - Plataforma: Navegador de computador; WASD para mover, J/K para socar, L para bloquear e Espaço para esquivar; sem login nem download.
+  - GPT-6 Astra: [Declaração do criador](https://x.com/sonic0828/status/2097601232877781344) — A apresentação do criador cita GPT-6 Astra como ferramenta de geração dos minijogos; a resposta sobre boxe inclui o link desta versão. [Notas de verificação](assets/screenshots/underground-boxing/SOURCE.md).
+  - Recursos: [Link de lançamento do criador](https://x.com/sonic0828/status/2097601584410796401)
+  - Prévia: ![Dois boxeadores trocando golpes em um ringue subterrâneo iluminado, com tempo, vida e resistência.](assets/screenshots/underground-boxing/gameplay.jpg)
+
+- **[Urban Champion 3D](https://iamsonic.net/2026/mini-games/urban-champion.html)** — Troque socos altos e baixos numa rua ao pôr do sol, bloqueie contra-ataques e empurre o rival para um bueiro enquanto desvia de vasos que caem.
+  - Criador: [Sonic的奇思妙想](https://x.com/sonic0828)
+  - Plataforma: Navegador de computador; A/D para mover, J/K para socar, U/I para bloquear e Espaço para esquivar; sem login.
+  - GPT-6 Astra: [Declaração do criador](https://x.com/sonic0828/status/2097601232877781344) — A apresentação de GPT-6 Astra do criador inclui uma resposta de lançamento separada com o link deste jogo de luta de rua. [Notas de verificação](assets/screenshots/urban-champion-3d/SOURCE.md).
+  - Recursos: [Link de lançamento do criador](https://x.com/sonic0828/status/2097601861658587376)
+  - Prévia: ![Lutadores azul e vermelho diante da Sunset Mart, com cronômetro do round e barras de resistência.](assets/screenshots/urban-champion-3d/gameplay.jpg)
+
+- **[Zero District — Shells 3D](https://iamsonic.net/2026/mini-games/shells-3d/play.html)** — Sobreviva a um cerco urbano de três minutos com disparo automático, esquivas por movimento, coleta de experiência e escolha de melhorias.
+  - Criador: [Sonic的奇思妙想](https://x.com/sonic0828)
+  - Plataforma: Navegador; WASD ou arrastar para mover, mira automática; sem login nem download.
+  - GPT-6 Astra: [Declaração do criador](https://x.com/sonic0828/status/2097601232877781344) — O criador cita GPT-6 Astra no anúncio da coleção e publica esta versão de sobrevivência 3D em uma resposta dedicada. [Notas de verificação](assets/screenshots/zero-district-shells-3d/SOURCE.md).
+  - Recursos: [Link de lançamento do criador](https://x.com/sonic0828/status/2097602391122264310)
+  - Prévia: ![Sobrevivente atirando automaticamente nos inimigos da rua, com 14 derrotados e 166 segundos restantes.](assets/screenshots/zero-district-shells-3d/gameplay.jpg)
+
+- **[ASCII DISTRICT](https://ascii-district.vercel.app/)** — Enfrente ondas de vírus de computador numa arena em primeira pessoa desenhada com caracteres ASCII, correndo, pulando e deslizando.
+  - Criador: [Acker Code](https://x.com/acker_code)
+  - Plataforma: Navegador de computador; teclado e mouse, sem login. Clique na arena para capturar o mouse; Esc o libera.
+  - GPT-6 Astra: [Declaração do criador](https://x.com/acker_code/status/2097542957070975286) — O criador credita explicitamente Codex e GPT-6 Astra pelo jogo de tiro em arte ASCII. [Notas de verificação](assets/screenshots/ascii-district/SOURCE.md).
+  - Prévia: ![Pátio ASCII com vírus se aproximando e indicador do rifle com 29 balas após um disparo.](assets/screenshots/ascii-district/gameplay.jpg)
+
+- **[Aura Farming: Unbothered](https://www.aigameshare.com/games/aura-farming-game)** — Equilibre uma capivara dançarina num barco-dragão, incline-se contra as ondas e complete seis movimentos antes de acabar o tempo de 40 segundos.
+  - Criador: [nilni / @nil](https://www.aigameshare.com/profile/nil)
+  - Plataforma: Navegador de computador; jogo grátis sem login. Clique em Play; recursos de conta são opcionais.
+  - GPT-6 Astra: [Página do criador](https://www.aigameshare.com/games/aura-farming-game) — O criador credita GPT-6 Astra e Codex, além de Blender, Three.js, ImageGen e WebAudio. [Notas de verificação](assets/screenshots/aura-farming/SOURCE.md).
+  - Prévia: ![Capivara dançando num barco-dragão, com controles de inclinação e apoio e desafio de seis movimentos.](assets/screenshots/aura-farming/gameplay.jpg)
+
 <a id="puzzles"></a>
 
 ### Quebra-cabeças e raciocínio
@@ -135,6 +199,25 @@ Desafios de lógica e física, jogos de palavras e pequenos mecanismos engenhoso
   - Participação do modelo: [Registro de criação](works/sunjing-puzzles/CREATION.md) — Trabalho iterativo no Codex sobre design do jogo, visuais 3D procedurais, regras, solucionador e testes; o uso específico de GPT-6 Astra aguarda confirmação do criador (envio preliminar).
   - Recursos: [Código-fonte e instruções de execução](works/sunjing-puzzles/README.md) · [Requisitos](works/sunjing-puzzles/PROMPTS.md) · Tecnologias: React, Vinext/Vite, Three.js.
   - Prévia: ![Quebra-cabeça de madeira de seis peças de Sunjing sobre uma bancada 3D verde, com peças numeradas e controles de extração.](assets/screenshots/sunjing-puzzles/gameplay.jpg)
+
+- **[CityMaker](https://citymaker.0to1app.com)** — Um quebra-cabeça 2048 num quarteirão 4×4: una prédios iguais para avançar por onze níveis arquitetônicos em cada cidade, de casas tradicionais a um horizonte reconhecível, em doze cidades com câmera girando em passos de 45°.
+  - Criador: [Derek Wang](https://github.com/derek-wangpch)
+  - Plataforma: Navegadores de computador e celular com WebGL; inglês, chinês simplificado e tradicional. Grátis, sem login ou chave API; progresso por cidade salvo no navegador atual e instalação na tela inicial do iOS disponível.
+  - GPT-6 Astra: [Registro de criação](https://github.com/derek-wangpch/OpenCityMaker/blob/master/docs/CREATION.md) — O criador relata usar GPT-6 Astra para gerar a geometria procedural dos 132 prédios, com referências, pesquisa de múltiplas vistas, volumes baseados na silhueta e validação por capturas; não foi um teste de prompt único.
+  - Recursos: [Código e configuração](https://github.com/derek-wangpch/OpenCityMaker) · [Notas de verificação](https://github.com/derek-wangpch/OpenCityMaker/blob/master/QA.md) · Tecnologias: React, TypeScript, Vite e Three.js; os 132 modelos de prédios são geometria procedural original.
+  - Prévia: ![Tabuleiro de Hong Kong de CityMaker com prédios 3D low-poly em uma grade 4×4, pontuação, seleção de cidades e rotação.](assets/screenshots/citymaker/gameplay.png)
+
+- **[Bonkshot](https://bonkshot.com/)** — Puxe um estilingue e lance pequenos Bonkers contra suportes de madeira para derrubar estruturas e eliminar alvos.
+  - Criador: [edmund5](https://x.com/edmund5)
+  - Plataforma: Navegador; arraste para mirar e solte para lançar. Jogável sem login; entrar com Google é opcional.
+  - GPT-6 Astra: [Declaração do criador](https://x.com/edmund5/status/2097603093819261002) — O criador credita GPT-6 Astra e Three.js pelo jogo e Suno pela música de fundo. [Notas de verificação](assets/screenshots/bonkshot/SOURCE.md).
+  - Prévia: ![Primeiro quebra-cabeça de Grasslands após um lançamento: torre parcialmente caída, um alvo restante e 2.200 pontos.](assets/screenshots/bonkshot/gameplay.jpg)
+
+- **[Greenhouse Escape Room: The Last Seed](https://www.aigameshare.com/games/greenhouse-escape-room)** — Explore uma estufa fechada, restaure canos de cobre, organize plantas e luz refletida e resgate a última semente.
+  - Criador: [nilni / @nil](https://www.aigameshare.com/profile/nil)
+  - Plataforma: Navegador; clique em Play e depois Begin. Grátis, sem login; controles em inglês e chinês.
+  - GPT-6 Astra: [Página do criador](https://www.aigameshare.com/games/greenhouse-escape-room) — O criador identifica GPT-6 Astra e Codex como ferramentas de desenvolvimento, com ImageGen e WebAudio. [Notas de verificação](assets/screenshots/greenhouse-escape-room/SOURCE.md).
+  - Prévia: ![Sala Waterworks da estufa, com mecanismo de canos de nove peças, cronômetro e inventário.](assets/screenshots/greenhouse-escape-room/gameplay.jpg)
 
 <a id="strategy-simulation"></a>
 
@@ -227,6 +310,24 @@ Defesa de torres, cartas estratégicas, gerenciamento, construção e simulaçã
   - Recursos: [GitHub](https://github.com/LucasMarquesShiva/the-free-game)
   - Prévia: ![The Free Game](assets/screenshots/the-free-game/gameplay.jpg)
 
+- **[AGI of Empires — The Compute Wars](https://agiofempires.com/)** — Reúna financiamento e GPUs, construa centros de dados e exércitos e vença laboratórios rivais na corrida à ASI ou destrua suas sedes.
+  - Criador: [timour kosters](https://x.com/timourxyz)
+  - Plataforma: Navegador de computador; estratégia em tempo real satírica e gratuita. Início contra o computador e coleta de recursos verificados sem login.
+  - GPT-6 Astra: [X](https://x.com/timourxyz/status/2096662786692776293) — O criador afirma ter desenvolvido este jogo inspirado em Age of Empires com Astra em dois dias. [Notas de verificação](assets/screenshots/agi-of-empires/SOURCE.md).
+  - Prévia: ![Campo de batalha de AGI of Empires, contadores de recursos e sede.](assets/screenshots/agi-of-empires/gameplay.jpg)
+
+- **[Atlas Go](https://atlas-go.borisxp.chatgpt.site/)** — Jogue go em redes de ruas e tabuleiros de grafos incomuns, com turnos locais no mesmo aparelho e opções de partidas com amigos.
+  - Criador: [Boris Power](https://x.com/BorisMPower)
+  - Plataforma: Navegador; tabuleiro local aberto sem login. Partidas online com amigos não foram testadas.
+  - GPT-6 Astra: [X](https://x.com/BorisMPower/status/2096784808399843582) — O criador descreve este go multijogador em grafos arbitrários como uma criação do Astra com um único prompt. [Notas de verificação](assets/screenshots/atlas-go/SOURCE.md).
+  - Prévia: ![Pedras pretas e brancas no grafo em colmeia de Atlas Go.](assets/screenshots/atlas-go/gameplay.jpg)
+
+- **[Ironwood — The Art of Industry](https://ironwood.sparkles.dev/)** — Colete matérias-primas, alimente máquinas e conecte esteiras para transformar uma clareira em uma fábrica em funcionamento.
+  - Criador: [Dan](https://x.com/aidaniil)
+  - Plataforma: Navegador de computador; tutorial de visitante sem login, mas salvar o progresso exige login. Multijogador não testado de forma independente.
+  - GPT-6 Astra: [X](https://x.com/aidaniil/status/2096426970930106530) — O criador afirma que ele e o irmão construíram o jogo com Astra, Blender MCP e Cloudflare Durable Objects, inspirados em Satisfactory e Besiege. [Notas de verificação](assets/screenshots/ironwood/SOURCE.md).
+  - Prévia: ![Máquinas, esteiras e tutorial de gestão de recursos de Ironwood.](assets/screenshots/ironwood/gameplay.jpg)
+
 - **[DUST FRONT](https://dust-front.mustafaakin.dev/)** — RTS para um jogador com construção de base, captura de pontos e comando de forças terrestres e aéreas.
   - Criador: [Mustafa Akın](https://x.com/mustafaakin)
   - Plataforma: Navegador desktop; teclado e mouse, sem login obrigatório.
@@ -239,6 +340,18 @@ Defesa de torres, cartas estratégicas, gerenciamento, construção e simulaçã
   - GPT-6 Astra: [X](https://x.com/HDLhN783wtLkpPR/status/2097321360641122393) — Na publicação vinculada, o criador afirma ter usado “GPT Astra” para criar este jogo de estratégia em tempo real; a versão exata do modelo e o processo detalhado de desenvolvimento não são especificados.
   - Referências: [Submissão](https://github.com/MartinDelophy/awesome-gpt-6-astra/issues/66) · [Notas de verificação (inglês)](assets/screenshots/frontline-command/SOURCE.md)
   - Prévia: ![Frontline Command: base, três tanques selecionados e posicionamento de uma usina durante uma partida; v0.8, capturada em 2026-09-09.](assets/screenshots/frontline-command/gameplay.jpg)
+
+- **[Coin Pusher Roguelite: Mintfall](https://www.aigameshare.com/games/coin-pusher-roguelite-mintfall)** — Mire num empurrador de moedas 3D, combine moedas especiais e relíquias e vença seis rodadas com lançamentos limitados e metas de pontuação.
+  - Criador: [nilni / @nil](https://www.aigameshare.com/profile/nil)
+  - Plataforma: Navegador; clique em Play, grátis e sem login. Salvamento com conta opcional.
+  - GPT-6 Astra: [Página do criador](https://www.aigameshare.com/games/coin-pusher-roguelite-mintfall) — O criador credita GPT-6 Astra junto com GPT-5.6 Sol e Codex; a página não separa suas contribuições. [Notas de verificação](assets/screenshots/mintfall/SOURCE.md).
+  - Prévia: ![Bandeja 3D de Mintfall na rodada 1, com 33 pontos, 44 lançamentos e controles de moedas especiais.](assets/screenshots/mintfall/gameplay.jpg)
+
+- **[Westward — The Oregon Trail](https://biswaz.me/westward/)** — Guie uma caravana para o oeste, racione comida, cuide de reparos e caça e tome decisões ao longo da Trilha do Oregon.
+  - Criador: [Biswas](https://x.com/bis_waz)
+  - Plataforma: Navegador de computador; comece com o grupo fictício fornecido, sem login ou instalação.
+  - GPT-6 Astra: [X](https://x.com/bis_waz/status/2098023593468907747) — Biswas afirma ter usado GPT-6 Astra para esta versão moderna 3D de The Oregon Trail e fornece o link jogável. [Notas de verificação](assets/screenshots/westward/SOURCE.md).
+  - Prévia: ![Carroça e bois a caminho do rio Kansas, com 25 milhas percorridas e painel de suprimentos.](assets/screenshots/westward/gameplay.jpg)
 
 <a id="rpg-adventures"></a>
 
@@ -276,6 +389,63 @@ RPG, exploração, aventuras narrativas e histórias interativas.
   - Plataforma: Navegador de desktop; aberto sem login ou pagamento. Celular não testado.
   - GPT-6 Astra: [X](https://x.com/emollick/status/2096047660662722620) — O autor informa ter usado Astra no desenvolvimento deste projeto. [Notas de verificação (inglês)](assets/screenshots/zork/SOURCE.md).
   - Prévia: ![Zork · The Great Underground Empire](assets/screenshots/zork/gameplay.jpg)
+
+- **[The Simpsons: Hit & Run — Browser Recreation](https://vheissu.github.io/hit-and-run-web/)** — Explore Springfield a pé e de carro numa recriação não oficial para navegador, com missões, trânsito e perseguições policiais.
+  - Criador: [Dwayne](https://x.com/CtrlAltDwayne)
+  - Plataforma: Navegador de computador; primeira missão carregada sem login após uma carga inicial grande de recursos. A campanha completa não foi testada.
+  - GPT-6 Astra: [X](https://x.com/CtrlAltDwayne/status/2096872309936287887) — O criador descreve a reconstrução para a web com GPT-6 Astra; o repositório também credita ajuda do Claude no carregamento. Os recursos do jogo original mantêm seus próprios direitos. [Notas de verificação](assets/screenshots/hit-and-run-web/SOURCE.md).
+  - Recursos: [Código e configuração](https://github.com/Vheissu/hit-and-run-web)
+  - Prévia: ![Homer em Springfield, com objetivo da primeira missão e minimapa.](assets/screenshots/hit-and-run-web/gameplay.jpg)
+
+- **[Where the Wind Wanders](https://app.usecrayon.ai/play/a9a3c165-74b3-4ff6-9588-ad97f829ddb5)** — Passeie por um vale ensolarado em 2.5D, siga trilhas e encontre três cartas do vento numa aventura tranquila de exploração.
+  - Criador: [Tushar](https://x.com/TusharXo)
+  - Plataforma: Navegador, hospedado no Crayon; página pública e player incorporado verificados.
+  - GPT-6 Astra: [X](https://x.com/TusharXo/status/2096037482739683574) — Tushar descreve Astra gerando caminhos e recursos; uma publicação posterior anuncia a versão jogável com Astra, Three.js e Crayon. [Notas de verificação](assets/screenshots/crayon-adventure/SOURCE.md).
+  - Recursos: [Anúncio de lançamento do criador](https://x.com/TusharXo/status/2096741535891251261)
+  - Prévia: ![Personagem explorando um vale florido, com objetivo das cartas do vento visível.](assets/screenshots/crayon-adventure/gameplay.jpg)
+
+- **[ALIBI — The Last Light](https://alibi-blackthorn-manor.vercel.app/)** — Investigue Blackthorn Manor num mistério de assassinato point-and-click, examinando cenas e seguindo pistas para identificar o culpado.
+  - Criador: [Christos Antonopoulos](https://x.com/Christos_antono)
+  - Plataforma: Navegador; entrada interativa da mansão aberta sem login. Cenas geradas posteriores não foram testadas por completo.
+  - GPT-6 Astra: [X](https://x.com/Christos_antono/status/2096435122669297892) — O criador credita GPT Astra e H3 Max pelo jogo de investigação generativo. [Notas de verificação](assets/screenshots/alibi-blackthorn-manor/SOURCE.md).
+  - Prévia: ![Entrada da mansão com porta clicável e texto inicial da investigação.](assets/screenshots/alibi-blackthorn-manor/gameplay.jpg)
+
+- **[Skyward: The Gathering](https://edge-city-skyward-quests.vercel.app/)** — Explore ilhas flutuantes, pule e plane entre comunidades e cumpra missões para os moradores.
+  - Criador: [timour kosters](https://x.com/timourxyz)
+  - Plataforma: Navegador de computador, teclado e mouse; página e controles da edição com missões verificados.
+  - GPT-6 Astra: [X](https://x.com/timourxyz/status/2096379521926840339) — O criador afirma que Astra construiu um jogo 3D jogável com NPCs e missões inspirados em locais de Edge City. [Notas de verificação](assets/screenshots/skyward-gathering/SOURCE.md).
+  - Prévia: ![Visão das ilhas flutuantes de Skyward com exploração e diário.](assets/screenshots/skyward-gathering/gameplay.jpg)
+
+- **[Anna & Leo · The Starstone Adventure](https://anna-leo-starstone.vercel.app/)** — Alterne entre a magia musical de Anna e os superpoderes de Leo para despertar flores melódicas e explorar Wonder Garden.
+  - Criador: [Dharma Utomo](https://x.com/dharmautomo)
+  - Plataforma: Navegador; missão inicial iniciada sem login. WASD para mover, Espaço para pular, E para poder e Tab para trocar de herói.
+  - GPT-6 Astra: [X](https://x.com/dharmautomo/status/2096573649235091967) — O criador afirma que GPT-6 Astra ajudou a construir a aventura 3D e compartilha um vídeo dos filhos testando o jogo. [Notas de verificação](assets/screenshots/anna-leo-starstone/SOURCE.md).
+  - Prévia: ![Mundo de aventura 3D de Anna e Leo com interface de missões.](assets/screenshots/anna-leo-starstone/gameplay.jpg)
+
+- **[The Legend of Deller](https://rain-court-js.umodeler-inc-4323.chatgpt.site/)** — Explore Rainmist Haven e avance rumo às masmorras com combos de espada, habilidades elementais e movimentos evasivos.
+  - Criador: [UModeler X PicoBerry](https://x.com/UModeler)
+  - Plataforma: Navegador de computador; teclado e mouse, sem login. Aguarde o carregamento inicial dos recursos 3D.
+  - GPT-6 Astra: [Declaração do criador](https://x.com/UModeler/status/2097792348407099553) — O criador afirma que PicoBerry gerou os recursos e GPT-6 Astra construiu o RPG de ação em Three.js ao redor deles. [Notas de verificação](assets/screenshots/the-legend-of-deller/SOURCE.md).
+  - Recursos: [Link de lançamento do criador](https://x.com/UModeler/status/2097792351129178451)
+  - Prévia: ![Deller esquivando perto de uma fonte e barracas em Rainmist Haven, com vida, mana e habilidades.](assets/screenshots/the-legend-of-deller/gameplay.jpg)
+
+- **[Dungeon of Astra](https://wavedash.com/games/dungeon-of-astra)** — Recrute um grupo, desça uma masmorra de cem andares e combine golpes de espada, bolas de fogo e funções dos companheiros numa partida com morte permanente.
+  - Criador: [tonysuri / @tonysurix](https://x.com/tonysurix)
+  - Plataforma: Navegador de computador no Wavedash; jogo base inicia sem login. Há contas opcionais e desbloqueios antecipados pagos de personagens.
+  - GPT-6 Astra: [Declaração do criador](https://x.com/tonysurix/status/2097873333551616355) — O criador afirma explicitamente que este explorador de masmorras em grupo foi criado com GPT-6 Astra. [Notas de verificação](assets/screenshots/dungeon-of-astra/SOURCE.md).
+  - Prévia: ![Herói e cavaleiro contratado lançando uma bola de fogo no primeiro andar, com vida do grupo e minimapa.](assets/screenshots/dungeon-of-astra/gameplay.jpg)
+
+- **[Sunlandia — The Forgotten Shore](https://sunlandia.smallweblab.com/)** — Explore uma ilha após um naufrágio, investigue pistas em primeira pessoa e resolva enigmas ambientais no caminho até o farol.
+  - Criador: [Ramon Linares / Small Web Lab](https://github.com/RamonLinares)
+  - Plataforma: Navegador de computador; aguarde a ilha e clique em Begin expedition. Grátis, sem conta ou instalação.
+  - GPT-6 Astra: [Diário de desenvolvimento do criador](https://smallweblab.com/posts/sunlandia/) — O criador começou com GPT-5.6 Sol, contou com ajuda de Fable e terminou o jogo com GPT-6 Astra. [Notas de verificação](assets/screenshots/sunlandia/SOURCE.md).
+  - Prévia: ![Costa de Sunlandia em primeira pessoa, com naufrágio, cais quebrado e objetivo de procurar ajuda.](assets/screenshots/sunlandia/gameplay.jpg)
+
+- **[NÁCAR](https://nacar-microcosmo.preda2005.chatgpt.site/)** — Faça um organismo microscópico crescer dentro de uma concha de caracol inundada, reúna nutrientes e desenvolva novas partes do corpo ao explorar.
+  - Criador: [Marcio Lima / @Preda2005](https://x.com/Preda2005)
+  - Plataforma: Navegador; beta gratuita sem login, com cinco idiomas de interface, incluindo chinês.
+  - GPT-6 Astra: [Publicação do criador](https://x.com/Preda2005/status/2097954217180921928) — Marcio afirma que descreveu a ideia de evolução do organismo ao GPT-6 Astra e a desenvolveu até a beta vinculada. [Notas de verificação](assets/screenshots/nacar/SOURCE.md).
+  - Prévia: ![Pequena célula entre nutrientes coloridos, com biomassa, evolução, inventário e acompanhamento das águas exploradas.](assets/screenshots/nacar/gameplay.jpg)
 
 <a id="platformers-racing"></a>
 
@@ -341,6 +511,31 @@ Parkour, desafios de plataforma, corridas e jogos baseados em movimento e trajet
   - GPT-6 Astra: [Issue #51](https://github.com/MartinDelophy/awesome-gpt-6-astra/issues/51) — Segundo o criador: Primeira versão com Qwen3.8 Max; segunda totalmente reconstruída com Astra.
   - Prévia: ![疾风赛道 / Kart Racing（跑跑卡丁车）](https://github.com/user-attachments/assets/015e0ca1-7032-4d0e-9391-ad3f40d84227)
 
+- **[TIDAL RUSH — Paradise GP](https://tidal-rush-paradise-gp.skirano.chatgpt.site/)** — Derrape num circuito tropical de kart, use itens e dispute três voltas contra sete rivais.
+  - Criador: [Pietro Schirano](https://x.com/skirano)
+  - Plataforma: Navegador; corrida de três voltas iniciada sem login. Teclado para dirigir, derrapar e usar itens, além de botões de toque na tela.
+  - GPT-6 Astra: [Atribuição do modelo](https://openai.com/index/gpt-6-astra/) — A página de lançamento do Astra da OpenAI vincula este kart interativo e credita Pietro Schirano. A publicação de descoberta no X é da comunidade, não do criador. [Notas de verificação](assets/screenshots/tidal-rush/SOURCE.md).
+  - Recursos: [Descoberta no X](https://x.com/alexgetmancom/status/2095598460921614825)
+  - Prévia: ![Pista tropical de Tidal Rush, com posição na corrida e controles de derrapagem.](assets/screenshots/tidal-rush/gameplay.jpg)
+
+- **[LUNA — Crimson Requiem / 紅月のレクイエム](https://luna-crimson-requiem.ponsuke.chatgpt.site/)** — Pule por um cenário gótico em pixel art, corte ou pise nos inimigos ou invoque um ataque numa curta aventura de rolagem lateral.
+  - Criador: [音羽ぽんすけ](https://x.com/ponsuke_otowa)
+  - Plataforma: Navegador, interface japonesa; teclado e suporte a smartphones informado pelo criador. Uma fase disponível.
+  - GPT-6 Astra: [X](https://x.com/ponsuke_otowa/status/2096531744933425299) — O criador relata cerca de 25 minutos de desenvolvimento com Astra e uma correção da animação de caminhada; a música é creditada separadamente ao Suno. [Notas de verificação](assets/screenshots/luna-crimson-requiem/SOURCE.md).
+  - Prévia: ![LUNA lutando numa rua gótica sob uma lua vermelha, com vida e medidor de invocação.](assets/screenshots/luna-crimson-requiem/gameplay.jpg)
+
+- **[Strange Orbit](https://app.usecrayon.ai/play/47df78e2-1410-45d1-833c-196e1161c0b8)** — Corra com ciclistas astronautas pelos anéis de um planeta, colete poeira estelar, pegue o vácuo dos rivais e use impulso na Orbital Cup.
+  - Criador: [Crayon](https://x.com/usecrayon)
+  - Plataforma: Navegador no Crayon; teclado e controles de toque documentados. A página pública oferece corrida, contrarrelógio e passeio infinito.
+  - GPT-6 Astra: [X](https://x.com/usecrayon/status/2097468975995302167) — Crayon credita GPT-6 Astra, Crayon Pro e Three.js pelo jogo de ciclismo espacial. [Notas de verificação](assets/screenshots/crayon-space-bike/SOURCE.md).
+  - Prévia: ![Ciclistas astronautas num anel planetário, com voltas, posição e poeira estelar.](assets/screenshots/crayon-space-bike/gameplay.jpg)
+
+- **[One More Vine — Into the Wild](https://onemorevine.bennash.dev/)** — Corra, pule e balance por quatro fases de selva, colete tesouros e evite crocodilos enquanto melhora seu tempo.
+  - Criador: [Ben Nash](https://x.com/bennash)
+  - Plataforma: Navegador, teclado e controles na tela; fase inicial e instruções carregadas sem login.
+  - GPT-6 Astra: [X](https://x.com/bennash/status/2096282758930645170) — O criador o descreve explicitamente como um jogo de quatro fases inspirado em Pitfall e feito com GPT-6 Astra. [Notas de verificação](assets/screenshots/one-more-vine/SOURCE.md).
+  - Prévia: ![Fase de plataforma na selva com cipós, tesouros, buracos e crocodilos.](assets/screenshots/one-more-vine/gameplay.jpg)
+
 - **[混合马里奥Ⅱ · 忍者龙剑传 × 坦克大战 / Mario Mix II](https://aha-xiaoq.github.io/games/mario-mix-2/play.html)** — Explore o mundo subterrâneo 1-2 de Mario com Ryu Hayabusa de Ninja Gaiden e o tanque de Battle City: saltos, escalada de paredes e combates em visão lateral com Ryu, batalhas em visão superior com o tanque ou um revezamento de ninja para tanque para resgatar a princesa.
   - Criador: [在下_小Q（Aha-xiaoQ）](https://github.com/Aha-xiaoQ)
   - Plataforma: Navegador de computador, interface em chinês, teclado recomendado; grátis, sem login ou instalação.
@@ -349,6 +544,37 @@ Parkour, desafios de plataforma, corridas e jogos baseados em movimento e trajet
   - Direitos: Jogo de fã não oficial; os personagens, imagens e músicas clássicos mantêm os direitos de seus respectivos titulares. Veja os créditos dos materiais na página do jogo original.
   - Prévia: ![Mario Mix II — capa de vídeo fornecida pelo criador, não uma captura de uma partida.](https://aha-xiaoq.github.io/games/mario-mix-2/cover.jpg)
   - Captura de tela: ![O tanque de Mario Mix II dispara na entrada do mundo 1-2; versão 1.0 em execução, capturada em 2026-09-09.](assets/screenshots/mario-mix-2/gameplay.jpg)
+
+- **[Bengaluru ORR Rush](https://orr-rush-bengaluru.ravitheja.chatgpt.site/)** — Corra no trânsito de Bengaluru, desvie de buracos e motos de entrega e use impulso ou uma manobra lateral para abrir espaço.
+  - Criador: [Ravi Theja](https://x.com/ravithejads)
+  - Plataforma: Navegador de computador; teclado com aceleração automática opcional, sem login.
+  - GPT-6 Astra: [Declaração do criador](https://x.com/ravithejads/status/2097181044625887392) — O criador atribui o jogo de corrida nas ruas de Bengaluru ao GPT-6 Astra. [Notas de verificação](assets/screenshots/bengaluru-orr-rush/SOURCE.md).
+  - Prévia: ![Carro azul do jogador no trânsito de Bengaluru, com posição, velocidade, cronômetro e controles.](assets/screenshots/bengaluru-orr-rush/gameplay.jpg)
+
+- **[SKICROSS — Alpine Downhill](https://iamsonic.net/2026/mini-games/skicross.html)** — Dispute uma descida de montanha contra três esquiadores, passe por portões e obstáculos e fique à frente da avalanche.
+  - Criador: [Sonic的奇思妙想](https://x.com/sonic0828)
+  - Plataforma: Navegador de computador; A/D para virar, Espaço para pular e Shift para impulsionar; sem login nem download.
+  - GPT-6 Astra: [Declaração do criador](https://x.com/sonic0828/status/2097601232877781344) — O criador atribui a coleção de minijogos ao GPT-6 Astra e apresenta este jogo de esqui em uma resposta dedicada. [Notas de verificação](assets/screenshots/skicross/SOURCE.md).
+  - Recursos: [Link de lançamento do criador](https://x.com/sonic0828/status/2097601732297814300)
+  - Prévia: ![Quatro esquiadores na neve, com bônus de portão, classificação, velocidade e distância da avalanche.](assets/screenshots/skicross/gameplay.jpg)
+
+- **[Itsy Bitsy Spider · One More Climb](https://game-bench.piccini.app/games/gpt-6-astra/)** — Suba uma parede coberta de musgo, capture moscas para recuperar a aderência e esconda-se em buracos de abrigo antes que a chuva carregue a aranha.
+  - Criador: [Luiz Piccini](https://piccini.app/)
+  - Plataforma: Navegador; grátis, sem login. WASD ou joystick na tela.
+  - GPT-6 Astra: [Game Bench do criador](https://game-bench.piccini.app/) — Game Bench identifica esta criação publicada como GPT-6 Astra canary, high, datada de 2026-09-05 e feita a partir de sua proposta compartilhada de jogo. [Notas de verificação](assets/screenshots/itsy-bitsy-spider/SOURCE.md).
+  - Prévia: ![Aranha a dois metros numa parede de tijolos com musgo, com aderência, moscas, abrigo e joystick.](assets/screenshots/itsy-bitsy-spider/gameplay.jpg)
+
+- **[Desi Mayhem](https://desimayhem.com/)** — Corra de moto pelo trânsito urbano da Índia, costure entre ônibus e riquixás e use chutes, socos e impulsos.
+  - Criador: [Kishore](https://x.com/GetKishore)
+  - Plataforma: Navegador de computador; grátis, sem conta. Aceite ou edite o apelido gerado antes da primeira corrida.
+  - GPT-6 Astra: [Relato de desenvolvimento do criador](https://x.com/GetKishore/status/2097906401159102811) — Kishore descreve iterações do jogo 3D feito com Astra usando referências de ruas e testes repetidos de trânsito, colisões e combate entre pilotos. [Notas de verificação](assets/screenshots/desi-mayhem/SOURCE.md).
+  - Prévia: ![Corrida de motos em Chennai com piloto, trânsito, minimapa, posição e cronômetro.](assets/screenshots/desi-mayhem/gameplay.jpg)
+
+- **[Cosmic Tides](https://app.usecrayon.ai/play/362ae1e7-29bd-4fbc-9103-00649265d942)** — Pilote uma nave por um oceano galáctico, siga portões luminosos e escolha uma corrida de duas voltas ou uma deriva infinita.
+  - Criador: [Aniket J](https://x.com/aniketjart)
+  - Plataforma: Navegador; aguarde os recursos 3D e clique em Ride the current. Grátis, sem login.
+  - GPT-6 Astra: [X](https://x.com/aniketjart/status/2098207146647433534) — Aniket credita GPT-6 Astra, Blender MCP e Crayon; descreve um experimento com novas iterações de jogabilidade planejadas. [Notas de verificação](assets/screenshots/cosmic-tides/SOURCE.md).
+  - Prévia: ![Corrida de Cosmic Tides rumo a um portão luminoso sobre um mar galáctico, com voltas e velocidade.](assets/screenshots/cosmic-tides/gameplay.jpg)
 
 <a id="experimental-multiplayer"></a>
 
@@ -394,6 +620,12 @@ Mecânicas diferentes, competição online e experiências cooperativas.
   - Plataforma: Navegador, gratuito, sem conta. O criador informa que VPN/proxy pode ser necessário. Início solo verificado; multijogador não testado.
   - GPT-6 Astra: [Issue #52](https://github.com/MartinDelophy/awesome-gpt-6-astra/issues/52) — Segundo o criador: Primeira versão com GPT-6 Astra Pro; melhorias com GPT-6 Astra no Codex.
   - Prévia: ![泡泡坦克大作战联机版 / Toon Tank Arena](https://github.com/user-attachments/assets/713d44f3-a77c-452c-ba6d-1231882dc670)
+
+- **[Above the Rooftops](https://app.usecrayon.ai/play/d09bb865-2259-42e2-86cc-fb609a9d6f28)** — Pinte uma pipa e voe sobre os telhados, equilibrando a tensão da linha em voo livre ou num desafio cronometrado de luzes no céu.
+  - Criador: [Tushar / @TusharXo](https://x.com/TusharXo)
+  - Plataforma: Navegador; escolha um personagem, entre no terraço e selecione Fly. Grátis, sem login.
+  - GPT-6 Astra: [X](https://x.com/TusharXo/status/2098156783181467801) — Tushar credita explicitamente GPT-6 Astra e Crayon pelo jogo de pipas em Three.js e cita Images 2.5 para os visuais. [Notas de verificação](assets/screenshots/above-the-rooftops/SOURCE.md).
+  - Prévia: ![Desafio de pipa sobre a cidade, com altura, tensão da linha, progresso das luzes e direção.](assets/screenshots/above-the-rooftops/gameplay.jpg)
 
 ## O que cada entrada inclui
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -4,7 +4,7 @@
 
 # Awesome GPT-6 Astra
 
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](CONTRIBUTING.md) [![LINUX DO](https://img.shields.io/badge/LINUX%20DO-Community-f0b73f?style=flat-square)](https://linux.do/) [![Cases: 49](https://img.shields.io/badge/Cases-49-58a6ff?style=flat-square)](https://astragames.aigccreative.com/)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](CONTRIBUTING.md) [![LINUX DO](https://img.shields.io/badge/LINUX%20DO-Community-f0b73f?style=flat-square)](https://linux.do/) [![Cases: 86](https://img.shields.io/badge/Cases-86-58a6ff?style=flat-square)](https://astragames.aigccreative.com/)
 
 **Подборка интересных игр, созданных с помощью GPT-6 Astra.**
 
@@ -22,7 +22,7 @@
 
 ## С чего начать
 
-Здесь собраны **49 игр и интерактивных проектов**: территориальная стратегия эпохи Троецарствия, деревянные головоломки со сцепленными деталями и сдвижными блоками, объединение мягких фруктов, полёт одной кнопкой, сражения на ковре-самолёте, защита острова с помощью электросети, выживание в дикой природе, подводная охота, управление суши-рестораном и фермерство на острове, гонки на картах по Bay Circuit, велопрогулка с пеликаном вдоль берега, настольные игрушки в 3D и Orbital Garden. Нажмите на название, чтобы играть прямо в браузере.
+Здесь собраны **86 игр и интерактивных проектов**: территориальная стратегия эпохи Троецарствия, деревянные головоломки со сцепленными деталями и сдвижными блоками, объединение мягких фруктов, 2048 с процедурным строительством городов, полёт одной кнопкой, сражения на ковре-самолёте, шутер с завесами пуль и пятью уровнями, защита острова с помощью электросети, выживание в дикой природе, подводная охота, управление суши-рестораном и фермерство на острове, гонки на картах по Bay Circuit, велопрогулка с пеликаном вдоль берега, настольные игрушки в 3D, оформление дома в 3D и Orbital Garden. Нажмите на название, чтобы играть прямо в браузере.
 
 Каталог обновлён: **2026-09-12**. Сведения об использовании модели основаны на заявлениях авторов или отправителей; неподтверждённые данные отмечены в соответствующих записях. Эта дата означает обновление каталога, а не повторное игровое тестирование всех проектов.
 
@@ -110,6 +110,70 @@
   - GPT-6 Astra: [X](https://x.com/jumperz/status/2096600055301984738) — Автор сообщает об использовании Astra при разработке проекта. [Запись проверки (английский)](assets/screenshots/cinderfall/SOURCE.md).
   - Предпросмотр: ![Cinderfall · Fire, Shadow & Steel](assets/screenshots/cinderfall/gameplay.jpg)
 
+- **[Oz Breakdance](https://satriodewantono.com/breakdance/)** — Перетаскивайте конечности тряпичного танцора к соответствующим целям, чтобы набирать очки и продлевать раунд брейк-данса на время.
+  - Автор: [Satrio](https://x.com/satrio_d)
+  - Платформа: Браузер на компьютере, управление мышью; раунд на время запустился без входа в аккаунт.
+  - GPT-6 Astra: [X](https://x.com/satrio_d/status/2096022866097758500) — Автор сообщает, что Astra помогла улучшить его существующую игру о брейк-дансе и её оформление. [Примечания к проверке](assets/screenshots/breakdance/SOURCE.md).
+  - Предпросмотр: ![Тряпичный танцор тянется ногой к цели на арене брейк-данса с таймером.](assets/screenshots/breakdance/gameplay.jpg)
+
+- **[Astral War](https://astralwar.io/)** — Браузерный шутер от первого лица в тематике Второй мировой войны с обликами солдат и зомби, наборами оружия, тренировкой с ботами и настройками лобби.
+  - Автор: [Rishi](https://x.com/0xRishi)
+  - Платформа: Браузер на компьютере, клавиатура и мышь; тренировка с ботами запустилась без входа в аккаунт. Мультиплеер и поддержка контроллера не проверялись.
+  - GPT-6 Astra: [X](https://x.com/0xRishi/status/2096079660605997264) — Rishi сообщает, что создал Astral War с помощью Astra, Three.js, Meshy и ElevenLabs. На текущем сайте также указана Vesper; подробности приведены в примечании об участии моделей. [Примечания к проверке](assets/screenshots/astral-war/SOURCE.md).
+  - Предпросмотр: ![Боевой экран Astral War с оружием и элементами управления на поле боя.](assets/screenshots/astral-war/gameplay.jpg)
+
+- **[FLOP CLUB](https://bubucn.com/ai-model-evals/flop-club/game/index.html)** — Ныряйте с платформ трёх высот, делайте сальто и вращения и цельтесь в плавающее кольцо, чтобы повысить оценку за вход в воду.
+  - Автор: [BubuAi](https://x.com/BubuStd)
+  - Платформа: Браузер; отдельная страница игры запускается сразу, без входа в аккаунт и загрузок. Во время проверки 2026-09-09 был начат прыжок; доступны клавиатура и описанное в документации сенсорное управление.
+  - GPT-6 Astra: [X](https://x.com/BubuStd/status/2096402783805354091) — По словам автора, игра создана одним запросом к Astra Pro с использованием Three.js. [Примечания к проверке](assets/screenshots/flop-club/SOURCE.md).
+  - Материалы: [Описание проекта](https://bubucn.com/zh/ai-model-evals/flop-club)
+  - Предпросмотр: ![Прыгун на высокой платформе над кольцом-мишенью и элементы управления приземлением в воду.](assets/screenshots/flop-club/gameplay.jpg)
+
+- **[Vector Dive — Beyond the Signal](https://vector-dive.openai.chatgpt.site/)** — Летайте по неоновым каркасным трассам, которые ускоряются с каждым кругом, вовремя используя ускорение и фазовое перемещение, чтобы продержаться дольше.
+  - Автор: [Thomas Ricouard](https://x.com/Dimillian)
+  - Платформа: Браузер на компьютере; полёт с подсчётом очков запустился без входа в аккаунт. WASD — полёт, Space — ускорение, Shift — фазовое перемещение.
+  - GPT-6 Astra: [X](https://x.com/Dimillian/status/2097188900888322323) — Автор сообщает, что Astra создала игру и музыку по визуальному заданию в стиле неона и синтвейва и концепт-артам. [Примечания к проверке](assets/screenshots/vector-dive/SOURCE.md).
+  - Предпросмотр: ![Неоновая трасса Vector Dive с кораблём игрока и игровым интерфейсом.](assets/screenshots/vector-dive/gameplay.jpg)
+
+- **[Harbor Skirmish](https://gpt6astra-game.vercel.app/)** — Защищайте приморский город от волн буйных кроликов, используя три вида оружия, маршруты по крышам, рывки и крюк-кошку.
+  - Автор: [OpenDesign](https://x.com/OpenDesignHQ)
+  - Платформа: Браузер на компьютере; клавиатура и мышь, без входа в аккаунт и загрузок.
+  - GPT-6 Astra: [Заявление автора](https://x.com/OpenDesignHQ/status/2097635757917983223) — OpenDesign указывает, что в сравнении двух моделей эта игра на Three.js представляет версию, созданную с GPT-6 Astra. [Примечания к проверке](assets/screenshots/harbor-skirmish/SOURCE.md).
+  - Предпросмотр: ![Вид от первого лица с винтовкой на город Seabreeze, приближающихся кроликов, счётчик волн и управление оружием.](assets/screenshots/harbor-skirmish/gameplay.jpg)
+
+- **[UNDERGROUND — Underground Boxing](https://iamsonic.net/2026/mini-games/underground-boxing.html)** — Проведите три раунда на время в подпольном 3D-ринге, сочетая удары, блоки, уклонения и расход выносливости.
+  - Автор: [Sonic的奇思妙想](https://x.com/sonic0828)
+  - Платформа: Браузер на компьютере; WASD — движение, J/K — удары, L — блок, Space — уклонение; без входа в аккаунт и загрузок.
+  - GPT-6 Astra: [Заявление автора](https://x.com/sonic0828/status/2097601232877781344) — В ветке с подборкой автор называет GPT-6 Astra инструментом создания этих мини-игр; ответ о боксе содержит ссылку на эту версию. [Примечания к проверке](assets/screenshots/underground-boxing/SOURCE.md).
+  - Материалы: [Ссылка автора на релиз](https://x.com/sonic0828/status/2097601584410796401)
+  - Предпросмотр: ![Два боксёра обмениваются ударами на освещённом подпольном ринге; видны таймер раунда, здоровье и выносливость.](assets/screenshots/underground-boxing/gameplay.jpg)
+
+- **[Urban Champion 3D](https://iamsonic.net/2026/mini-games/urban-champion.html)** — Обменивайтесь верхними и нижними ударами на улице на закате, блокируйте контратаки и загоняйте соперника в люк, избегая падающих цветочных горшков.
+  - Автор: [Sonic的奇思妙想](https://x.com/sonic0828)
+  - Платформа: Браузер на компьютере; A/D — движение, J/K — удары, U/I — блоки, Space — уклонение; без входа в аккаунт.
+  - GPT-6 Astra: [Заявление автора](https://x.com/sonic0828/status/2097601232877781344) — В подборке автора, посвящённой GPT-6 Astra, есть отдельный ответ о релизе со ссылкой на эту уличную драку. [Примечания к проверке](assets/screenshots/urban-champion-3d/SOURCE.md).
+  - Материалы: [Ссылка автора на релиз](https://x.com/sonic0828/status/2097601861658587376)
+  - Предпросмотр: ![Синий и красный бойцы обмениваются ударами у Sunset Mart; видны таймер раунда и шкалы выносливости.](assets/screenshots/urban-champion-3d/gameplay.jpg)
+
+- **[Zero District — Shells 3D](https://iamsonic.net/2026/mini-games/shells-3d/play.html)** — Переживите трёхминутную осаду города с автоматической стрельбой, уклонением за счёт движения, сбором опыта и выбором улучшений.
+  - Автор: [Sonic的奇思妙想](https://x.com/sonic0828)
+  - Платформа: Браузер; движение через WASD или перетаскивание, автоматическое прицеливание; без входа в аккаунт и загрузок.
+  - GPT-6 Astra: [Заявление автора](https://x.com/sonic0828/status/2097601232877781344) — Автор указывает GPT-6 Astra в анонсе подборки и публикует ссылку на эту 3D-игру на выживание в отдельном ответе. [Примечания к проверке](assets/screenshots/zero-district-shells-3d/SOURCE.md).
+  - Материалы: [Ссылка автора на релиз](https://x.com/sonic0828/status/2097602391122264310)
+  - Предпросмотр: ![Выживший автоматически стреляет по окружающим врагам на городской улице; 14 побеждённых противников и 166 секунд до конца.](assets/screenshots/zero-district-shells-3d/gameplay.jpg)
+
+- **[ASCII DISTRICT](https://ascii-district.vercel.app/)** — Сражайтесь с волнами компьютерных вирусов на арене от первого лица, изображённой символами ASCII, используя бег, прыжки и скольжение.
+  - Автор: [Acker Code](https://x.com/acker_code)
+  - Платформа: Браузер на компьютере; клавиатура и мышь, без входа в аккаунт. Щелчок по арене захватывает указатель мыши, Esc освобождает его.
+  - GPT-6 Astra: [Заявление автора](https://x.com/acker_code/status/2097542957070975286) — Автор прямо указывает Codex и GPT-6 Astra как инструменты создания этого ASCII-шутера. [Примечания к проверке](assets/screenshots/ascii-district/SOURCE.md).
+  - Предпросмотр: ![Двор из ASCII-символов с приближающимися вирусами; после выстрела интерфейс винтовки показывает 29 патронов.](assets/screenshots/ascii-district/gameplay.jpg)
+
+- **[Aura Farming: Unbothered](https://www.aigameshare.com/games/aura-farming-game)** — Удерживайте равновесие танцующей капибары на лодке-драконе, наклоняйтесь навстречу волнам и выполните шесть движений за 40 секунд.
+  - Автор: [nilni / @nil](https://www.aigameshare.com/profile/nil)
+  - Платформа: Браузер на компьютере; бесплатно, без входа в аккаунт. Нажмите Play; функции аккаунта необязательны.
+  - GPT-6 Astra: [Страница автора с игрой](https://www.aigameshare.com/games/aura-farming-game) — Автор указывает GPT-6 Astra и Codex наряду с Blender, Three.js, ImageGen и WebAudio как инструменты создания игры. [Примечания к проверке](assets/screenshots/aura-farming/SOURCE.md).
+  - Предпросмотр: ![Капибара танцует на лодке-драконе; видны управление наклоном и упором и интерфейс испытания из шести движений.](assets/screenshots/aura-farming/gameplay.jpg)
+
 <a id="puzzles"></a>
 
 ### Головоломки и логические игры
@@ -135,6 +199,25 @@
   - Участие модели: [История создания](works/sunjing-puzzles/CREATION.md) — Итеративная работа в Codex над дизайном игры, процедурной 3D-графикой, правилами, решателем и тестами; точное использование GPT-6 Astra ожидает подтверждения автора (черновая заявка).
   - Материалы: [Исходный код и инструкция по запуску](works/sunjing-puzzles/README.md) · [Требования](works/sunjing-puzzles/PROMPTS.md) · Технологии: React, Vinext/Vite, Three.js.
   - Предпросмотр: ![Деревянная головоломка Sunjing из шести деталей на зелёном 3D-верстаке с номерами деталей и кнопками извлечения.](assets/screenshots/sunjing-puzzles/gameplay.jpg)
+
+- **[CityMaker](https://citymaker.0to1app.com)** — Головоломка 2048 на городском участке 4×4: объединяйте одинаковые здания, проходя 11 архитектурных уровней в каждом из 12 городов — от традиционных домов до узнаваемого силуэта города. Вид можно поворачивать с шагом 45°.
+  - Автор: [Derek Wang](https://github.com/derek-wangpch)
+  - Платформа: Браузеры на компьютерах и мобильных устройствах с WebGL; английский, упрощённый и традиционный китайский. Бесплатно, без входа в аккаунт и API-ключа; прогресс сохраняется отдельно для каждого города в текущем браузере. Игру можно установить на домашний экран iOS.
+  - GPT-6 Astra: [История создания](https://github.com/derek-wangpch/OpenCityMaker/blob/master/docs/CREATION.md) — Автор сообщает, что использовал GPT-6 Astra для создания процедурной геометрии всех 132 моделей зданий, изучая референсы с разных ракурсов, сначала выстраивая объёмы по силуэту и проверяя результат по скриншотам; это не тест с единственным запросом.
+  - Материалы: [Исходный код и настройка](https://github.com/derek-wangpch/OpenCityMaker) · [Примечания к проверке](https://github.com/derek-wangpch/OpenCityMaker/blob/master/QA.md) · Технологии: React, TypeScript, Vite и Three.js; все 132 модели зданий — оригинальная процедурная геометрия.
+  - Предпросмотр: ![Поле Гонконга в CityMaker: низкополигональные 3D-здания на сетке 4×4, счёт, панель выбора городов и управление поворотом.](assets/screenshots/citymaker/gameplay.png)
+
+- **[Bonkshot](https://bonkshot.com/)** — Натягивайте рогатку и запускайте маленьких Bonker в деревянные опоры, чтобы обрушить сооружения и убрать цели.
+  - Автор: [edmund5](https://x.com/edmund5)
+  - Платформа: Браузер; тяните для прицеливания и отпускайте для выстрела. Можно играть без входа в аккаунт; вход через Google необязателен.
+  - GPT-6 Astra: [Заявление автора](https://x.com/edmund5/status/2097603093819261002) — Автор указывает GPT-6 Astra и Three.js как инструменты создания игры, а Suno — для фоновой музыки. [Примечания к проверке](assets/screenshots/bonkshot/SOURCE.md).
+  - Предпросмотр: ![Первая головоломка Grasslands после выстрела: частично разрушенная деревянная башня, одна оставшаяся цель и 2 200 очков.](assets/screenshots/bonkshot/gameplay.jpg)
+
+- **[Greenhouse Escape Room: The Last Seed](https://www.aigameshare.com/games/greenhouse-escape-room)** — Исследуйте запертую теплицу, восстановите медные водопроводные трубы, расположите растения и отражённый свет и спасите последнее семя.
+  - Автор: [nilni / @nil](https://www.aigameshare.com/profile/nil)
+  - Платформа: Браузер; нажмите Play, затем Begin. Бесплатно, без входа в аккаунт; элементы управления на английском и китайском.
+  - GPT-6 Astra: [Страница автора с игрой](https://www.aigameshare.com/games/greenhouse-escape-room) — Автор называет GPT-6 Astra и Codex инструментами разработки наряду с ImageGen и WebAudio. [Примечания к проверке](assets/screenshots/greenhouse-escape-room/SOURCE.md).
+  - Предпросмотр: ![Комната Waterworks в игре о побеге из теплицы: трубный механизм из девяти плиток, таймер и инвентарь.](assets/screenshots/greenhouse-escape-room/gameplay.jpg)
 
 <a id="strategy-simulation"></a>
 
@@ -227,6 +310,24 @@
   - Ресурсы: [GitHub](https://github.com/LucasMarquesShiva/the-free-game)
   - Предпросмотр: ![The Free Game](assets/screenshots/the-free-game/gameplay.jpg)
 
+- **[AGI of Empires — The Compute Wars](https://agiofempires.com/)** — Собирайте финансирование и GPU, стройте дата-центры и армии, чтобы обогнать конкурирующие ИИ-лаборатории в достижении ASI или уничтожить их штаб-квартиры.
+  - Автор: [timour kosters](https://x.com/timourxyz)
+  - Платформа: Браузер на компьютере; бесплатная сатирическая стратегия в реальном времени. Начальный матч против компьютера и сбор ресурсов проверены без входа в аккаунт.
+  - GPT-6 Astra: [X](https://x.com/timourxyz/status/2096662786692776293) — Автор сообщает, что за два дня разработал эту игру, вдохновлённую Age of Empires, с помощью Astra. [Примечания к проверке](assets/screenshots/agi-of-empires/SOURCE.md).
+  - Предпросмотр: ![Поле боя AGI of Empires, счётчики ресурсов и штаб-квартира.](assets/screenshots/agi-of-empires/gameplay.jpg)
+
+- **[Atlas Go](https://atlas-go.borisxp.chatgpt.site/)** — Играйте в го на уличных сетях и необычных графовых досках; доступны поочерёдная игра на одном устройстве и партии с друзьями.
+  - Автор: [Boris Power](https://x.com/BorisMPower)
+  - Платформа: Браузер; локальная доска открылась без входа в аккаунт. Онлайн-партии с друзьями не проверялись.
+  - GPT-6 Astra: [X](https://x.com/BorisMPower/status/2096784808399843582) — Автор описывает многопользовательское го на произвольных графах как результат одного запроса к Astra. [Примечания к проверке](assets/screenshots/atlas-go/SOURCE.md).
+  - Предпросмотр: ![Чёрные и белые камни на сотовой графовой доске Atlas Go.](assets/screenshots/atlas-go/gameplay.jpg)
+
+- **[Ironwood — The Art of Industry](https://ironwood.sparkles.dev/)** — Собирайте сырьё, снабжайте машины энергией и соединяйте конвейеры, чтобы превратить поляну в работающую фабрику.
+  - Автор: [Dan](https://x.com/aidaniil)
+  - Платформа: Браузер на компьютере; гостевой учебный режим открывается без входа в аккаунт, но для сохранения прогресса вход необходим. Мультиплеер независимо не проверялся.
+  - GPT-6 Astra: [X](https://x.com/aidaniil/status/2096426970930106530) — Автор сообщает, что вместе с братом создал игру с Astra, Blender MCP и Cloudflare Durable Objects, вдохновляясь Satisfactory и Besiege. [Примечания к проверке](assets/screenshots/ironwood/SOURCE.md).
+  - Предпросмотр: ![Машины фабрики Ironwood, конвейеры и обучение управлению ресурсами.](assets/screenshots/ironwood/gameplay.jpg)
+
 - **[DUST FRONT](https://dust-front.mustafaakin.dev/)** — Одиночная RTS со строительством базы, захватом точек и управлением наземными и воздушными силами.
   - Автор: [Mustafa Akın](https://x.com/mustafaakin)
   - Платформа: Настольный браузер; клавиатура и мышь, вход в аккаунт не требуется.
@@ -239,6 +340,18 @@
   - GPT-6 Astra: [X](https://x.com/HDLhN783wtLkpPR/status/2097321360641122393) — В указанной публикации автор сообщает, что создал эту RTS с помощью «GPT Astra»; точная версия модели и подробный процесс разработки не указаны.
   - Ссылки: [Заявка](https://github.com/MartinDelophy/awesome-gpt-6-astra/issues/66) · [Заметки о проверке (английский)](assets/screenshots/frontline-command/SOURCE.md)
   - Предпросмотр: ![Frontline Command: база, три выбранных танка и размещение электростанции во время матча; v0.8, снимок от 2026-09-09.](assets/screenshots/frontline-command/gameplay.jpg)
+
+- **[Coin Pusher Roguelite: Mintfall](https://www.aigameshare.com/games/coin-pusher-roguelite-mintfall)** — Цельтесь в 3D-автомате, сталкивающем монеты, комбинируйте особые монеты и реликвии и пройдите шесть раундов с ограничением на броски и целевым количеством очков.
+  - Автор: [nilni / @nil](https://www.aigameshare.com/profile/nil)
+  - Платформа: Браузер; нажмите Play, бесплатно и без входа в аккаунт. По желанию можно сохранять прогресс через аккаунт.
+  - GPT-6 Astra: [Страница автора с игрой](https://www.aigameshare.com/games/coin-pusher-roguelite-mintfall) — Автор указывает GPT-6 Astra вместе с GPT-5.6 Sol и Codex; на странице игры их вклад не разделён. [Примечания к проверке](assets/screenshots/mintfall/SOURCE.md).
+  - Предпросмотр: ![3D-лоток с монетами Mintfall в первом раунде: 33 очка, 44 броска и управление особыми монетами.](assets/screenshots/mintfall/gameplay.jpg)
+
+- **[Westward — The Oregon Trail](https://biswaz.me/westward/)** — Ведите обоз на запад, распределяйте еду, занимайтесь ремонтом и охотой и принимайте решения на Орегонской тропе.
+  - Автор: [Biswas](https://x.com/bis_waz)
+  - Платформа: Браузер на компьютере; начните с предложенной вымышленной команды, без входа в аккаунт и установки.
+  - GPT-6 Astra: [X](https://x.com/bis_waz/status/2098023593468907747) — Biswas сообщает, что с помощью GPT-6 Astra создал эту современную 3D-версию The Oregon Trail, и даёт ссылку на игру. [Примечания к проверке](assets/screenshots/westward/SOURCE.md).
+  - Предпросмотр: ![Повозка и волы на пути к Kansas River; пройдено 25 миль, видна панель припасов экспедиции.](assets/screenshots/westward/gameplay.jpg)
 
 <a id="rpg-adventures"></a>
 
@@ -276,6 +389,63 @@
   - Платформа: Настольный браузер; открыто без входа и оплаты. Мобильная версия не проверялась.
   - GPT-6 Astra: [X](https://x.com/emollick/status/2096047660662722620) — Автор сообщает об использовании Astra при разработке проекта. [Запись проверки (английский)](assets/screenshots/zork/SOURCE.md).
   - Предпросмотр: ![Zork · The Great Underground Empire](assets/screenshots/zork/gameplay.jpg)
+
+- **[The Simpsons: Hit & Run — Browser Recreation](https://vheissu.github.io/hit-and-run-web/)** — Исследуйте Springfield пешком и на машине в неофициальной браузерной реконструкции с миссиями, дорожным движением и полицейскими погонями.
+  - Автор: [Dwayne](https://x.com/CtrlAltDwayne)
+  - Платформа: Браузер на компьютере; первая миссия загрузилась без входа в аккаунт после первоначальной загрузки большого объёма ресурсов. Полное прохождение кампании не проверялось.
+  - GPT-6 Astra: [X](https://x.com/CtrlAltDwayne/status/2096872309936287887) — Автор описывает воссоздание игры для веба с GPT-6 Astra; в репозитории также указана помощь Claude с загрузкой. Права на ресурсы оригинальной игры сохраняются за их правообладателями. [Примечания к проверке](assets/screenshots/hit-and-run-web/SOURCE.md).
+  - Материалы: [Исходный код и настройка](https://github.com/Vheissu/hit-and-run-web)
+  - Предпросмотр: ![Homer в Springfield; видны цель первой миссии и мини-карта.](assets/screenshots/hit-and-run-web/gameplay.jpg)
+
+- **[Where the Wind Wanders](https://app.usecrayon.ai/play/a9a3c165-74b3-4ff6-9588-ad97f829ddb5)** — Бродите по залитой солнцем долине в 2.5D, следуйте тропам и соберите три письма ветра в спокойном приключении об исследовании мира.
+  - Автор: [Tushar](https://x.com/TusharXo)
+  - Платформа: Браузер, размещение на Crayon; проверены публичная страница игры и встроенный проигрыватель.
+  - GPT-6 Astra: [X](https://x.com/TusharXo/status/2096037482739683574) — Tushar описывает создание путей и ресурсов с Astra; в следующей публикации он объявляет о доступной для игры версии на Astra, Three.js и Crayon. [Примечания к проверке](assets/screenshots/crayon-adventure/SOURCE.md).
+  - Материалы: [Публикация автора о релизе](https://x.com/TusharXo/status/2096741535891251261)
+  - Предпросмотр: ![Персонаж исследует долину, полную цветов; видна цель по сбору писем ветра.](assets/screenshots/crayon-adventure/gameplay.jpg)
+
+- **[ALIBI — The Last Light](https://alibi-blackthorn-manor.vercel.app/)** — Расследуйте убийство в Blackthorn Manor в приключении с управлением мышью: осматривайте сцены и следуйте уликам, чтобы найти убийцу.
+  - Автор: [Christos Antonopoulos](https://x.com/Christos_antono)
+  - Платформа: Браузер; интерактивный вход в особняк открылся без входа в аккаунт. Последующие генерируемые сцены не проверялись полностью.
+  - GPT-6 Astra: [X](https://x.com/Christos_antono/status/2096435122669297892) — Автор указывает GPT Astra и H3 Max как инструменты создания этой генеративной детективной игры. [Примечания к проверке](assets/screenshots/alibi-blackthorn-manor/SOURCE.md).
+  - Предпросмотр: ![Вход в особняк с кликабельной дверью и начальным текстом расследования.](assets/screenshots/alibi-blackthorn-manor/gameplay.jpg)
+
+- **[Skyward: The Gathering](https://edge-city-skyward-quests.vercel.app/)** — Исследуйте парящие острова, прыгайте и планируйте между поселениями и выполняйте задания жителей.
+  - Автор: [timour kosters](https://x.com/timourxyz)
+  - Платформа: Браузер на компьютере, клавиатура и мышь; проверены страница версии с заданиями и управление.
+  - GPT-6 Astra: [X](https://x.com/timourxyz/status/2096379521926840339) — По словам автора, Astra создала доступную для игры 3D-игру с NPC и заданиями, вдохновлёнными местами Edge City. [Примечания к проверке](assets/screenshots/skyward-gathering/SOURCE.md).
+  - Предпросмотр: ![Общий вид парящих островов Skyward и элементы управления исследованием и журналом.](assets/screenshots/skyward-gathering/gameplay.jpg)
+
+- **[Anna & Leo · The Starstone Adventure](https://anna-leo-starstone.vercel.app/)** — Переключайтесь между музыкальной магией Anna и суперспособностями Leo, чтобы пробуждать цветы-мелодии и исследовать Wonder Garden.
+  - Автор: [Dharma Utomo](https://x.com/dharmautomo)
+  - Платформа: Браузер; начальное задание запустилось без входа в аккаунт. WASD — движение, Space — прыжок, E — способность, Tab — смена героя.
+  - GPT-6 Astra: [X](https://x.com/dharmautomo/status/2096573649235091967) — Автор сообщает, что GPT-6 Astra помогла создать 3D-приключение, и делится видео, где его дети тестируют игру. [Примечания к проверке](assets/screenshots/anna-leo-starstone/SOURCE.md).
+  - Предпросмотр: ![3D-мир приключений Anna и Leo и интерфейс заданий.](assets/screenshots/anna-leo-starstone/gameplay.jpg)
+
+- **[The Legend of Deller](https://rain-court-js.umodeler-inc-4323.chatgpt.site/)** — Исследуйте Rainmist Haven и отправляйтесь к подземельям, используя серии ударов мечом, стихийные умения и уклонения.
+  - Автор: [UModeler X PicoBerry](https://x.com/UModeler)
+  - Платформа: Браузер на компьютере; клавиатура и мышь, без входа в аккаунт. Дождитесь первоначальной загрузки 3D-ресурсов.
+  - GPT-6 Astra: [Заявление автора](https://x.com/UModeler/status/2097792348407099553) — Автор сообщает, что PicoBerry сгенерировала ресурсы, а GPT-6 Astra построила вокруг них экшен-RPG на Three.js. [Примечания к проверке](assets/screenshots/the-legend-of-deller/SOURCE.md).
+  - Материалы: [Ссылка автора на релиз](https://x.com/UModeler/status/2097792351129178451)
+  - Предпросмотр: ![Deller уклоняется возле фонтана и рыночных прилавков Rainmist Haven; видны здоровье, мана и управление умениями.](assets/screenshots/the-legend-of-deller/gameplay.jpg)
+
+- **[Dungeon of Astra](https://wavedash.com/games/dungeon-of-astra)** — Наберите отряд, спуститесь в подземелье из ста этажей и сочетайте удары мечом, огненные шары и роли спутников в забеге с необратимой смертью.
+  - Автор: [tonysuri / @tonysurix](https://x.com/tonysurix)
+  - Платформа: Браузер на компьютере, Wavedash; основная игра запускается без входа в аккаунт. Доступны необязательные аккаунты и платное раннее открытие персонажей.
+  - GPT-6 Astra: [Заявление автора](https://x.com/tonysurix/status/2097873333551616355) — Автор прямо сообщает, что эта игра с отрядом и исследованием подземелий создана с GPT-6 Astra. [Примечания к проверке](assets/screenshots/dungeon-of-astra/SOURCE.md).
+  - Предпросмотр: ![Герой и нанятый рыцарь на первом этаже подземелья во время атаки огненным шаром; здоровье отряда и мини-карта.](assets/screenshots/dungeon-of-astra/gameplay.jpg)
+
+- **[Sunlandia — The Forgotten Shore](https://sunlandia.smallweblab.com/)** — Исследуйте остров после кораблекрушения, ищите улики от первого лица и решайте загадки окружения на пути к маяку.
+  - Автор: [Ramon Linares / Small Web Lab](https://github.com/RamonLinares)
+  - Платформа: Браузер на компьютере; дождитесь острова, затем нажмите Begin expedition. Бесплатно, без аккаунта и установки.
+  - GPT-6 Astra: [Дневник разработки автора](https://smallweblab.com/posts/sunlandia/) — Автор начал с GPT-5.6 Sol, воспользовался помощью Fable и завершил игру с GPT-6 Astra. [Примечания к проверке](assets/screenshots/sunlandia/SOURCE.md).
+  - Предпросмотр: ![Берег Sunlandia от первого лица: обломки корабля, сломанный причал и цель найти помощь.](assets/screenshots/sunlandia/gameplay.jpg)
+
+- **[NÁCAR](https://nacar-microcosmo.preda2005.chatgpt.site/)** — Выращивайте микроскопический организм внутри затопленной раковины улитки, собирайте питательные вещества и развивайте новые части тела по мере исследования.
+  - Автор: [Marcio Lima / @Preda2005](https://x.com/Preda2005)
+  - Платформа: Браузер; бесплатная бета без входа в аккаунт, пять языков интерфейса, включая китайский.
+  - GPT-6 Astra: [Ветка автора](https://x.com/Preda2005/status/2097954217180921928) — Marcio сообщает, что описал GPT-6 Astra идею эволюции организма и развил её в доступную по ссылке бету. [Примечания к проверке](assets/screenshots/nacar/SOURCE.md).
+  - Предпросмотр: ![Маленькая клетка среди цветных питательных частиц; биомасса, эволюция, инвентарь и элементы интерфейса исследованных вод.](assets/screenshots/nacar/gameplay.jpg)
 
 <a id="platformers-racing"></a>
 
@@ -341,6 +511,31 @@
   - GPT-6 Astra: [Issue #51](https://github.com/MartinDelophy/awesome-gpt-6-astra/issues/51) — По словам автора: Первая версия — Qwen3.8 Max, вторая полностью переработана с Astra.
   - Предпросмотр: ![疾风赛道 / Kart Racing（跑跑卡丁车）](https://github.com/user-attachments/assets/015e0ca1-7032-4d0e-9391-ad3f40d84227)
 
+- **[TIDAL RUSH — Paradise GP](https://tidal-rush-paradise-gp.skirano.chatgpt.site/)** — Дрифтуйте на тропической картинговой трассе, применяйте предметы и соревнуйтесь с семью соперниками на протяжении трёх кругов.
+  - Автор: [Pietro Schirano](https://x.com/skirano)
+  - Платформа: Браузер; гонка на три круга запустилась без входа в аккаунт. Клавиатурное управление ездой, дрифтом и предметами, а также сенсорные кнопки на экране.
+  - GPT-6 Astra: [Подтверждение использования модели](https://openai.com/index/gpt-6-astra/) — На странице запуска Astra от OpenAI есть ссылка на эту интерактивную картинговую игру с указанием Pietro Schirano как автора. Публикация в X — это сообщение участника сообщества, а не самого автора игры. [Примечания к проверке](assets/screenshots/tidal-rush/SOURCE.md).
+  - Материалы: [Публикация об игре в X](https://x.com/alexgetmancom/status/2095598460921614825)
+  - Предпросмотр: ![Тропическая трасса Tidal Rush с позицией в гонке и управлением дрифтом.](assets/screenshots/tidal-rush/gameplay.jpg)
+
+- **[LUNA — Crimson Requiem / 紅月のレクイエム](https://luna-crimson-requiem.ponsuke.chatgpt.site/)** — Прыгайте по готическому пиксельному уровню, рубите врагов, прыгайте им на головы или призывайте атаку в коротком приключении с боковой прокруткой.
+  - Автор: [音羽ぽんすけ](https://x.com/ponsuke_otowa)
+  - Платформа: Браузер, японский интерфейс; клавиатурное управление и заявленная автором поддержка смартфонов. Доступен один уровень.
+  - GPT-6 Astra: [X](https://x.com/ponsuke_otowa/status/2096531744933425299) — Автор сообщает примерно о 25 минутах разработки с Astra и одной правке анимации ходьбы; музыка отдельно приписана Suno. [Примечания к проверке](assets/screenshots/luna-crimson-requiem/SOURCE.md).
+  - Предпросмотр: ![LUNA сражается на готической улице под красной луной; видны шкалы здоровья и призыва.](assets/screenshots/luna-crimson-requiem/gameplay.jpg)
+
+- **[Strange Orbit](https://app.usecrayon.ai/play/47df78e2-1410-45d1-833c-196e1161c0b8)** — Гоняйте на велосипедах с астронавтами по кольцам планеты, собирайте звёздную пыль, используйте воздушный след соперников и ускоряйтесь в Orbital Cup.
+  - Автор: [Crayon](https://x.com/usecrayon)
+  - Платформа: Браузер на Crayon; клавиатура и описанное в документации сенсорное управление. Публичная страница предлагает гонку, заезд на время и бесконечное странствие.
+  - GPT-6 Astra: [X](https://x.com/usecrayon/status/2097468975995302167) — Crayon указывает GPT-6 Astra, Crayon Pro и Three.js как инструменты создания космической велогонки. [Примечания к проверке](assets/screenshots/crayon-space-bike/SOURCE.md).
+  - Предпросмотр: ![Астронавты-велосипедисты на кольце планеты; индикаторы круга, позиции и звёздной пыли.](assets/screenshots/crayon-space-bike/gameplay.jpg)
+
+- **[One More Vine — Into the Wild](https://onemorevine.bennash.dev/)** — Бегите, прыгайте и раскачивайтесь на лианах на четырёх уровнях джунглей, собирайте сокровища и избегайте крокодилов, улучшая время прохождения.
+  - Автор: [Ben Nash](https://x.com/bennash)
+  - Платформа: Браузер, клавиатура и экранное управление движением; начальный уровень и инструкции загрузились без входа в аккаунт.
+  - GPT-6 Astra: [X](https://x.com/bennash/status/2096282758930645170) — Автор прямо называет её игрой из четырёх уровней, вдохновлённой Pitfall и созданной с GPT-6 Astra. [Примечания к проверке](assets/screenshots/one-more-vine/SOURCE.md).
+  - Предпросмотр: ![Уровень платформера в джунглях с висящими лианами, сокровищами, ямами и крокодилами.](assets/screenshots/one-more-vine/gameplay.jpg)
+
 - **[混合马里奥Ⅱ · 忍者龙剑传 × 坦克大战 / Mario Mix II](https://aha-xiaoq.github.io/games/mario-mix-2/play.html)** — Пройдите подземный мир 1-2 из Mario за Рю Хаябусу из Ninja Gaiden и танк из Battle City: прыжки, лазание по стенам и бои с видом сбоку за Рю, сражения с видом сверху за танк или эстафета от ниндзя к танку ради спасения принцессы.
   - Автор: [在下_小Q（Aha-xiaoQ）](https://github.com/Aha-xiaoQ)
   - Платформа: Браузер на компьютере, китайский интерфейс, рекомендуется клавиатура; бесплатно, без входа в аккаунт и установки.
@@ -349,6 +544,37 @@
   - Права: Неофициальная фанатская игра; права на классических персонажей, изображения и музыку остаются у соответствующих правообладателей. Источники материалов указаны на странице оригинальной игры.
   - Предпросмотр: ![Mario Mix II — предоставленная автором обложка видео, а не снимок игрового процесса.](https://aha-xiaoq.github.io/games/mario-mix-2/cover.jpg)
   - Скриншот: ![Танк в Mario Mix II стреляет у входа в мир 1-2; запущенная версия 1.0, снимок от 2026-09-09.](assets/screenshots/mario-mix-2/gameplay.jpg)
+
+- **[Bengaluru ORR Rush](https://orr-rush-bengaluru.ravitheja.chatgpt.site/)** — Мчитесь сквозь трафик Bengaluru, объезжайте выбоины и мотоциклы курьеров, используя ускорение или боковой рывок, чтобы освободить себе путь.
+  - Автор: [Ravi Theja](https://x.com/ravithejads)
+  - Платформа: Браузер на компьютере; клавиатурное управление с необязательной автоматической подачей газа, без входа в аккаунт.
+  - GPT-6 Astra: [Заявление автора](https://x.com/ravithejads/status/2097181044625887392) — Автор указывает GPT-6 Astra как инструмент создания гонки по дорогам Bengaluru. [Примечания к проверке](assets/screenshots/bengaluru-orr-rush/SOURCE.md).
+  - Предпросмотр: ![Синяя машина игрока в трафике Bengaluru; видны позиция, скорость, таймер и подсказки управления.](assets/screenshots/bengaluru-orr-rush/gameplay.jpg)
+
+- **[SKICROSS — Alpine Downhill](https://iamsonic.net/2026/mini-games/skicross.html)** — Соревнуйтесь с тремя лыжниками на спуске с горы, проходите ворота и препятствия и не дайте лавине вас догнать.
+  - Автор: [Sonic的奇思妙想](https://x.com/sonic0828)
+  - Платформа: Браузер на компьютере; A/D — поворот, Space — прыжок, Shift — ускорение; без входа в аккаунт и загрузок.
+  - GPT-6 Astra: [Заявление автора](https://x.com/sonic0828/status/2097601232877781344) — Автор связывает создание подборки мини-игр с GPT-6 Astra и публикует эту лыжную игру в отдельном ответе. [Примечания к проверке](assets/screenshots/skicross/SOURCE.md).
+  - Материалы: [Ссылка автора на релиз](https://x.com/sonic0828/status/2097601732297814300)
+  - Предпросмотр: ![Четыре лыжника на снежной трассе; бонус за ворота, места в гонке, скорость и расстояние до лавины.](assets/screenshots/skicross/gameplay.jpg)
+
+- **[Itsy Bitsy Spider · One More Climb](https://game-bench.piccini.app/games/gpt-6-astra/)** — Взбирайтесь по мшистой стене, ловите мух, чтобы восстановить хватку, и прячьтесь в укрытиях-отверстиях, пока дождь не смыл паука.
+  - Автор: [Luiz Piccini](https://piccini.app/)
+  - Платформа: Браузер; бесплатно, без входа в аккаунт. WASD или экранный джойстик.
+  - GPT-6 Astra: [Game Bench автора](https://game-bench.piccini.app/) — Game Bench помечает этот опубликованный результат как GPT-6 Astra canary, high, с датой 2026-09-05; он создан по общему игровому заданию платформы. [Примечания к проверке](assets/screenshots/itsy-bitsy-spider/SOURCE.md).
+  - Предпросмотр: ![Паук на высоте 2 метра на мшистой кирпичной стене; хватка, мухи, укрытие и джойстик движения.](assets/screenshots/itsy-bitsy-spider/gameplay.jpg)
+
+- **[Desi Mayhem](https://desimayhem.com/)** — Участвуйте в мотогонках среди индийского городского трафика, лавируйте между автобусами и авторикшами и используйте удары ногами, кулаками и ускорения.
+  - Автор: [Kishore](https://x.com/GetKishore)
+  - Платформа: Браузер на компьютере; бесплатно, без аккаунта. Перед первым заездом примите или измените сгенерированный псевдоним гонщика.
+  - GPT-6 Astra: [Ветка автора о разработке](https://x.com/GetKishore/status/2097906401159102811) — Kishore описывает доработку 3D-игры, созданной с Astra, с помощью уличных референсов и повторных проверок трафика, столкновений и боёв гонщиков. [Примечания к проверке](assets/screenshots/desi-mayhem/SOURCE.md).
+  - Предпросмотр: ![Мотогонка в Chennai: гонщик игрока, городской трафик, мини-карта, позиция и таймер гонки.](assets/screenshots/desi-mayhem/gameplay.jpg)
+
+- **[Cosmic Tides](https://app.usecrayon.ai/play/362ae1e7-29bd-4fbc-9103-00649265d942)** — Управляйте аппаратом над галактическим океаном, следуйте через светящиеся ворота и выберите гонку на два круга или бесконечный дрейф.
+  - Автор: [Aniket J](https://x.com/aniketjart)
+  - Платформа: Браузер; дождитесь 3D-ресурсов, затем нажмите Ride the current. Бесплатно, без входа в аккаунт.
+  - GPT-6 Astra: [X](https://x.com/aniketjart/status/2098207146647433534) — Aniket указывает GPT-6 Astra, Blender MCP и Crayon как инструменты создания игры и описывает её как эксперимент с планами дальнейшей доработки игрового процесса. [Примечания к проверке](assets/screenshots/cosmic-tides/SOURCE.md).
+  - Предпросмотр: ![Идущая гонка Cosmic Tides: приближение к светящимся воротам над галактическим морем, индикаторы круга и скорости.](assets/screenshots/cosmic-tides/gameplay.jpg)
 
 <a id="experimental-multiplayer"></a>
 
@@ -394,6 +620,12 @@
   - Платформа: Браузер, бесплатно, без регистрации. По словам автора, может понадобиться VPN/прокси. Одиночный запуск проверен; мультиплеер не проверялся.
   - GPT-6 Astra: [Issue #52](https://github.com/MartinDelophy/awesome-gpt-6-astra/issues/52) — По словам автора: Первая версия — GPT-6 Astra Pro, доработки — GPT-6 Astra в Codex.
   - Предпросмотр: ![泡泡坦克大作战联机版 / Toon Tank Arena](https://github.com/user-attachments/assets/713d44f3-a77c-452c-ba6d-1231882dc670)
+
+- **[Above the Rooftops](https://app.usecrayon.ai/play/d09bb865-2259-42e2-86cc-fb609a9d6f28)** — Раскрасьте воздушного змея и запускайте его над городскими крышами, регулируя натяжение нити в свободном полёте или испытании со сбором небесных огней на время.
+  - Автор: [Tushar / @TusharXo](https://x.com/TusharXo)
+  - Платформа: Браузер; выберите персонажа, выйдите на крышу и нажмите Fly. Бесплатно, без входа в аккаунт.
+  - GPT-6 Astra: [X](https://x.com/TusharXo/status/2098156783181467801) — Tushar прямо указывает GPT-6 Astra и Crayon как инструменты создания этой игры о воздушном змее на Three.js и упоминает Images 2.5 для визуальных материалов. [Примечания к проверке](assets/screenshots/above-the-rooftops/SOURCE.md).
+  - Предпросмотр: ![Испытание с воздушным змеем над городом; высота, натяжение нити, прогресс сбора небесных огней и управление направлением.](assets/screenshots/above-the-rooftops/gameplay.jpg)
 
 ## Что содержит запись
 


### PR DESCRIPTION
## 本次修改 / What changed

The English and Chinese READMEs contain 86 games, while the other ten translations contain 49. This PR translates the missing 37 entries into Spanish, French, German, Brazilian Portuguese, Japanese, Korean, Russian, Arabic, Hindi and Indonesian: 370 translated entries in total.

- Bring all 12 catalogs to the same 86 games, in the same categories and order.
- Translate gameplay descriptions, access requirements, model-use explanations, resource labels and screenshot alt text. Preserve mixed-model credits, optional login/payment details and the original verification limits.
- Update the translated count badges and introductions, including the missing city-building 2048, five-stage bullet-hell and 3D home-decoration highlights.

## 试玩与资料 / Demo and references

Translation maintenance only. The existing English catalog at commit `b526eb9326205172c460e2608a41cff8af379c30` is the source. No new games are introduced; the English and Chinese READMEs are unchanged.

All game, creator, attribution, reference and preview URLs in the 37 translated entries match their English counterparts. The existing 49 entries in each translation remain unchanged.

## 实机截图 / Gameplay screenshot

N/A — translation maintenance. The 37 existing gameplay screenshots are reused with translated alt text in every README; no image files are changed. The source entries' capture and verification notes are retained. This PR does not claim a fresh playtest of these games.

## 检查 / Quick check

- [x] All 12 READMEs contain the same 86 unique game URLs, with matching categories and order.
- [x] Verified all 370 additions against the English source, including creator credits, link targets and image paths; all 73 referenced local files exist.
- [x] Checked preservation of the existing 49 entries per translation and completed an independent translation review.
- [x] `git diff --check` passes.
- [x] `node --test website/tests/catalog.test.js website/tests/catalog-client.test.js website/tests/previews.test.js` — 27 tests pass.
- New-game playtesting and new screenshot capture: N/A for this translation-only PR.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes the game catalog in 10 translated READMEs so they now list the same 86 games as the English and Chinese versions instead of 49.

- Translates the 37 missing entries per language across Spanish, French, German, Brazilian Portuguese, Japanese, Korean, Russian, Arabic, Hindi, and Indonesian, totaling 370 entries.
- Updates count badges and intro highlights while preserving existing entries, game URLs, credits, and image paths; no new games or screenshots are introduced.

<sup>Written for commit 6c6d1c7d4c6a46cc8bace88117942ccba5bb1a0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MartinDelophy/awesome-gpt-6-astra/pull/78?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

